### PR TITLE
Added support for cancel_sm and query_sm SMPP messages

### DIFF
--- a/src/main/java/com/cloudhopper/smpp/pdu/CancelSm.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/CancelSm.java
@@ -1,0 +1,135 @@
+package com.cloudhopper.smpp.pdu;
+
+/*
+ * #%L
+ * ch-smpp
+ * %%
+ * Copyright (C) 2009 - 2013 Cloudhopper by Twitter
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.cloudhopper.commons.util.StringUtil;
+import com.cloudhopper.smpp.SmppConstants;
+import com.cloudhopper.smpp.type.Address;
+import com.cloudhopper.smpp.type.RecoverablePduException;
+import com.cloudhopper.smpp.type.UnrecoverablePduException;
+import com.cloudhopper.smpp.util.ChannelBufferUtil;
+import com.cloudhopper.smpp.util.PduUtil;
+import org.jboss.netty.buffer.ChannelBuffer;
+
+/**
+ * SMPP cancel_sm implementation.
+ *
+ * @author chris.matthews <idpromnut@gmail.com>
+ */
+public class CancelSm extends PduRequest<CancelSmResp> {
+
+
+
+    protected String serviceType;
+    protected String messageId;
+    protected Address sourceAddress;
+    protected Address destAddress;
+
+    public CancelSm() {
+        super(SmppConstants.CMD_ID_CANCEL_SM, "cancel_sm");
+    }
+
+    public String getServiceType() {
+        return this.serviceType;
+    }
+
+    public void setServiceType(String value) {
+        this.serviceType = value;
+    }
+
+    public String getMessageId() {
+        return this.messageId;
+    }
+
+    public void setMessageId(String value) {
+        this.messageId = value;
+    }
+
+    public Address getSourceAddress() {
+        return this.sourceAddress;
+    }
+
+    public void setSourceAddress(Address value) {
+        this.sourceAddress = value;
+    }
+
+    public Address getDestAddress() {
+        return this.destAddress;
+    }
+
+    public void setDestAddress(Address value) {
+        this.destAddress = value;
+    }
+
+
+    @Override
+    public void readBody(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
+        this.serviceType = ChannelBufferUtil.readNullTerminatedString(buffer);
+        this.messageId = ChannelBufferUtil.readNullTerminatedString(buffer);
+        this.sourceAddress = ChannelBufferUtil.readAddress(buffer);
+        this.destAddress = ChannelBufferUtil.readAddress(buffer);
+    }
+
+    @Override
+    public int calculateByteSizeOfBody() {
+        int bodyLength = 0;
+        bodyLength += PduUtil.calculateByteSizeOfNullTerminatedString(this.serviceType);
+        bodyLength += PduUtil.calculateByteSizeOfNullTerminatedString(this.messageId);
+        bodyLength += PduUtil.calculateByteSizeOfAddress(this.sourceAddress);
+        bodyLength += PduUtil.calculateByteSizeOfAddress(this.destAddress);
+        return bodyLength;
+    }
+
+    @Override
+    public void writeBody(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
+        ChannelBufferUtil.writeNullTerminatedString(buffer, this.serviceType);
+        ChannelBufferUtil.writeNullTerminatedString(buffer, this.messageId);
+        ChannelBufferUtil.writeAddress(buffer, this.sourceAddress);
+        ChannelBufferUtil.writeAddress(buffer, this.destAddress);
+    }
+
+    @Override
+    public void appendBodyToString(StringBuilder buffer) {
+        buffer.append("(serviceType [");
+        buffer.append(StringUtil.toStringWithNullAsEmpty(this.serviceType));
+        buffer.append("] messageId [");
+        buffer.append(StringUtil.toStringWithNullAsEmpty(this.messageId));
+        buffer.append("] sourceAddr [");
+        buffer.append(StringUtil.toStringWithNullAsEmpty(this.sourceAddress));
+        buffer.append("] destAddr [");
+        buffer.append(StringUtil.toStringWithNullAsEmpty(this.destAddress));
+        buffer.append("])");
+
+    }
+
+    @Override
+    public CancelSmResp createResponse() {
+        CancelSmResp resp = new CancelSmResp();
+        resp.setSequenceNumber(this.getSequenceNumber());
+        return resp;
+    }
+
+    @Override
+    public Class<CancelSmResp> getResponseClass() {
+        return CancelSmResp.class;
+    }
+
+}

--- a/src/main/java/com/cloudhopper/smpp/pdu/CancelSmResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/CancelSmResp.java
@@ -1,0 +1,57 @@
+package com.cloudhopper.smpp.pdu;
+
+/*
+ * #%L
+ * ch-smpp
+ * %%
+ * Copyright (C) 2009 - 2013 Cloudhopper by Twitter
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.cloudhopper.smpp.SmppConstants;
+import com.cloudhopper.smpp.type.RecoverablePduException;
+import com.cloudhopper.smpp.type.UnrecoverablePduException;
+import org.jboss.netty.buffer.ChannelBuffer;
+
+/**
+ * SMPP cancel_sm_resp implementation.
+ *
+ * @author chris.matthews <idpromnut@gmail.com>
+ */
+public class CancelSmResp extends PduResponse {
+
+    public CancelSmResp() {
+        super(SmppConstants.CMD_ID_CANCEL_SM_RESP, "cancel_sm_resp");
+    }
+
+    @Override
+    public void readBody(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
+        // nothing
+    }
+
+    @Override
+    public int calculateByteSizeOfBody() {
+        return 0;
+    }
+
+    @Override
+    public void writeBody(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
+        // do nothing
+    }
+
+    @Override
+    public void appendBodyToString(StringBuilder buffer) {
+    }
+}

--- a/src/main/java/com/cloudhopper/smpp/pdu/QuerySm.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/QuerySm.java
@@ -34,7 +34,7 @@ import org.jboss.netty.buffer.ChannelBuffer;
  *
  * @author chris.matthews <idpromnut@gmail.com>
  */
-public class QuerySm extends PduRequest<CancelSmResp> {
+public class QuerySm extends PduRequest<QuerySmResp> {
 
     private String messageId;
     private Address sourceAddress;
@@ -91,15 +91,15 @@ public class QuerySm extends PduRequest<CancelSmResp> {
     }
 
     @Override
-    public CancelSmResp createResponse() {
-        CancelSmResp resp = new CancelSmResp();
+    public QuerySmResp createResponse() {
+        QuerySmResp resp = new QuerySmResp();
         resp.setSequenceNumber(this.getSequenceNumber());
         return resp;
     }
 
     @Override
-    public Class<CancelSmResp> getResponseClass() {
-        return CancelSmResp.class;
+    public Class<QuerySmResp> getResponseClass() {
+        return QuerySmResp.class;
     }
 
 }

--- a/src/main/java/com/cloudhopper/smpp/pdu/QuerySm.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/QuerySm.java
@@ -1,0 +1,105 @@
+package com.cloudhopper.smpp.pdu;
+
+/*
+ * #%L
+ * ch-smpp
+ * %%
+ * Copyright (C) 2009 - 2013 Cloudhopper by Twitter
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.cloudhopper.commons.util.StringUtil;
+import com.cloudhopper.smpp.SmppConstants;
+import com.cloudhopper.smpp.type.Address;
+import com.cloudhopper.smpp.type.RecoverablePduException;
+import com.cloudhopper.smpp.type.UnrecoverablePduException;
+import com.cloudhopper.smpp.util.ChannelBufferUtil;
+import com.cloudhopper.smpp.util.PduUtil;
+import org.jboss.netty.buffer.ChannelBuffer;
+
+/**
+ * SMPP query_sm implementation.
+ *
+ * @author chris.matthews <idpromnut@gmail.com>
+ */
+public class QuerySm extends PduRequest<CancelSmResp> {
+
+    private String messageId;
+    private Address sourceAddress;
+
+    public QuerySm() {
+        super(SmppConstants.CMD_ID_QUERY_SM, "query_sm");
+    }
+
+    public String getMessageId() {
+        return this.messageId;
+    }
+
+    public void setMessageId(String value) {
+        this.messageId = value;
+    }
+
+    public Address getSourceAddress() {
+        return this.sourceAddress;
+    }
+
+    public void setSourceAddress(Address value) {
+        this.sourceAddress = value;
+    }
+
+
+    @Override
+    public void readBody(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
+        this.messageId = ChannelBufferUtil.readNullTerminatedString(buffer);
+        this.sourceAddress = ChannelBufferUtil.readAddress(buffer);
+    }
+
+    @Override
+    public int calculateByteSizeOfBody() {
+        int bodyLength = 0;
+        bodyLength += PduUtil.calculateByteSizeOfNullTerminatedString(this.messageId);
+        bodyLength += PduUtil.calculateByteSizeOfAddress(this.sourceAddress);
+        return bodyLength;
+    }
+
+    @Override
+    public void writeBody(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
+        ChannelBufferUtil.writeNullTerminatedString(buffer, this.messageId);
+        ChannelBufferUtil.writeAddress(buffer, this.sourceAddress);
+    }
+
+    @Override
+    public void appendBodyToString(StringBuilder buffer) {
+        buffer.append("(messageId [");
+        buffer.append(StringUtil.toStringWithNullAsEmpty(this.messageId));
+        buffer.append("] sourceAddr [");
+        buffer.append(StringUtil.toStringWithNullAsEmpty(this.sourceAddress));
+        buffer.append("])");
+
+    }
+
+    @Override
+    public CancelSmResp createResponse() {
+        CancelSmResp resp = new CancelSmResp();
+        resp.setSequenceNumber(this.getSequenceNumber());
+        return resp;
+    }
+
+    @Override
+    public Class<CancelSmResp> getResponseClass() {
+        return CancelSmResp.class;
+    }
+
+}

--- a/src/main/java/com/cloudhopper/smpp/pdu/QuerySmResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/QuerySmResp.java
@@ -1,0 +1,117 @@
+package com.cloudhopper.smpp.pdu;
+
+/*
+ * #%L
+ * ch-smpp
+ * %%
+ * Copyright (C) 2009 - 2013 Cloudhopper by Twitter
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.cloudhopper.commons.util.HexUtil;
+import com.cloudhopper.commons.util.StringUtil;
+import com.cloudhopper.smpp.SmppConstants;
+import com.cloudhopper.smpp.type.RecoverablePduException;
+import com.cloudhopper.smpp.type.UnrecoverablePduException;
+import com.cloudhopper.smpp.util.ChannelBufferUtil;
+import com.cloudhopper.smpp.util.PduUtil;
+import org.jboss.netty.buffer.ChannelBuffer;
+
+/**
+ * SMPP query_sm_resp implementation.
+ *
+ * @author chris.matthews <idpromnut@gmail.com>
+ */
+public class QuerySmResp extends PduResponse {
+
+    private String messageId;
+    private String finalDate;
+    private byte messageState;
+    private byte errorCode;
+
+    public QuerySmResp() {
+        super(SmppConstants.CMD_ID_QUERY_SM_RESP, "query_sm_resp");
+    }
+
+    public String getMessageId() {
+        return messageId;
+    }
+
+    public void setMessageId(final String iMessageId) {
+        messageId = iMessageId;
+    }
+
+    public String getFinalDate() {
+        return finalDate;
+    }
+
+    public void setFinalDate(final String iFinalDate) {
+        finalDate = iFinalDate;
+    }
+
+    public byte getMessageState() {
+        return messageState;
+    }
+
+    public void setMessageState(final byte iMessageState) {
+        messageState = iMessageState;
+    }
+
+    public byte getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(final byte iErrorCode) {
+        errorCode = iErrorCode;
+    }
+
+    @Override
+    public void readBody(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
+        this.messageId = ChannelBufferUtil.readNullTerminatedString(buffer);
+        this.finalDate = ChannelBufferUtil.readNullTerminatedString(buffer);
+        this.messageState = buffer.readByte();
+        this.errorCode = buffer.readByte();
+    }
+
+    @Override
+    public int calculateByteSizeOfBody() {
+        int bodyLength = 0;
+        bodyLength += PduUtil.calculateByteSizeOfNullTerminatedString(this.messageId);
+        bodyLength += PduUtil.calculateByteSizeOfNullTerminatedString(this.finalDate);
+        bodyLength += 2;    // messageState, errorCode
+        return bodyLength;
+    }
+
+    @Override
+    public void writeBody(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
+        ChannelBufferUtil.writeNullTerminatedString(buffer, this.messageId);
+        ChannelBufferUtil.writeNullTerminatedString(buffer, this.finalDate);
+        buffer.writeByte(this.messageState);
+        buffer.writeByte(this.errorCode);
+    }
+
+    @Override
+    public void appendBodyToString(StringBuilder buffer) {
+        buffer.append("(messageId [");
+        buffer.append(StringUtil.toStringWithNullAsEmpty(this.messageId));
+        buffer.append("] finalDate [");
+        buffer.append(StringUtil.toStringWithNullAsEmpty(this.finalDate));
+        buffer.append("] messageState [0x");
+        buffer.append(HexUtil.toHexString(this.messageState));
+        buffer.append("] errorCode [0x");
+        buffer.append(HexUtil.toHexString(this.errorCode));
+        buffer.append("])");
+    }
+}

--- a/src/main/java/com/cloudhopper/smpp/transcoder/DefaultPduTranscoder.java
+++ b/src/main/java/com/cloudhopper/smpp/transcoder/DefaultPduTranscoder.java
@@ -31,6 +31,8 @@ import com.cloudhopper.smpp.pdu.BindTransceiver;
 import com.cloudhopper.smpp.pdu.BindTransceiverResp;
 import com.cloudhopper.smpp.pdu.BindTransmitter;
 import com.cloudhopper.smpp.pdu.BindTransmitterResp;
+import com.cloudhopper.smpp.pdu.CancelSm;
+import com.cloudhopper.smpp.pdu.CancelSmResp;
 import com.cloudhopper.smpp.pdu.DataSm;
 import com.cloudhopper.smpp.pdu.DataSmResp;
 import com.cloudhopper.smpp.pdu.DeliverSm;
@@ -42,6 +44,8 @@ import com.cloudhopper.smpp.pdu.PartialPdu;
 import com.cloudhopper.smpp.pdu.PartialPduResp;
 import com.cloudhopper.smpp.pdu.Pdu;
 import com.cloudhopper.smpp.pdu.PduResponse;
+import com.cloudhopper.smpp.pdu.QuerySm;
+import com.cloudhopper.smpp.pdu.QuerySmResp;
 import com.cloudhopper.smpp.pdu.SubmitSm;
 import com.cloudhopper.smpp.pdu.SubmitSmResp;
 import com.cloudhopper.smpp.pdu.Unbind;
@@ -157,6 +161,10 @@ public class DefaultPduTranscoder implements PduTranscoder {
                 pdu = new SubmitSm();
             } else if (commandId == SmppConstants.CMD_ID_DATA_SM) {
                 pdu = new DataSm();
+            } else if (commandId == SmppConstants.CMD_ID_CANCEL_SM) {
+                pdu = new CancelSm();
+            } else if (commandId == SmppConstants.CMD_ID_QUERY_SM) {
+                pdu = new QuerySm();
             } else if (commandId == SmppConstants.CMD_ID_BIND_TRANSCEIVER) {
                 pdu = new BindTransceiver();
             } else if (commandId == SmppConstants.CMD_ID_BIND_TRANSMITTER) {
@@ -175,6 +183,10 @@ public class DefaultPduTranscoder implements PduTranscoder {
                 pdu = new DeliverSmResp();
             } else if (commandId == SmppConstants.CMD_ID_DATA_SM_RESP) {
                 pdu = new DataSmResp();
+            } else if (commandId == SmppConstants.CMD_ID_CANCEL_SM_RESP) {
+                pdu = new CancelSmResp();
+            } else if (commandId == SmppConstants.CMD_ID_QUERY_SM_RESP) {
+                pdu = new QuerySmResp();
             } else if (commandId == SmppConstants.CMD_ID_ENQUIRE_LINK_RESP) {
                 pdu = new EnquireLinkResp();
             } else if (commandId == SmppConstants.CMD_ID_BIND_TRANSCEIVER_RESP) {
@@ -211,7 +223,7 @@ public class DefaultPduTranscoder implements PduTranscoder {
         }
 
         try {
-            // parse pdu body paramters (may throw exception)
+            // parse pdu body parameters (may throw exception)
             pdu.readBody(buffer);
             // parse pdu optional parameters (may throw exception)
             pdu.readOptionalParameters(buffer, context);

--- a/src/test/java/com/cloudhopper/smpp/transcoder/PduDecoderTest.java
+++ b/src/test/java/com/cloudhopper/smpp/transcoder/PduDecoderTest.java
@@ -21,29 +21,12 @@ package com.cloudhopper.smpp.transcoder;
  */
 
 // third party imports
+import com.cloudhopper.smpp.pdu.*;
 import com.cloudhopper.smpp.type.UnrecoverablePduException;
 import com.cloudhopper.smpp.type.UnknownCommandIdException;
 import com.cloudhopper.smpp.type.TerminatingNullByteNotFoundException;
 import com.cloudhopper.commons.util.HexUtil;
 import com.cloudhopper.smpp.SmppConstants;
-import com.cloudhopper.smpp.pdu.BindReceiver;
-import com.cloudhopper.smpp.pdu.BindReceiverResp;
-import com.cloudhopper.smpp.pdu.BindTransceiver;
-import com.cloudhopper.smpp.pdu.BindTransceiverResp;
-import com.cloudhopper.smpp.pdu.BindTransmitter;
-import com.cloudhopper.smpp.pdu.BindTransmitterResp;
-import com.cloudhopper.smpp.pdu.BufferHelper;
-import com.cloudhopper.smpp.pdu.DataSm;
-import com.cloudhopper.smpp.pdu.DataSmResp;
-import com.cloudhopper.smpp.pdu.DeliverSm;
-import com.cloudhopper.smpp.pdu.DeliverSmResp;
-import com.cloudhopper.smpp.pdu.EnquireLink;
-import com.cloudhopper.smpp.pdu.EnquireLinkResp;
-import com.cloudhopper.smpp.pdu.GenericNack;
-import com.cloudhopper.smpp.pdu.SubmitSm;
-import com.cloudhopper.smpp.pdu.SubmitSmResp;
-import com.cloudhopper.smpp.pdu.Unbind;
-import com.cloudhopper.smpp.pdu.UnbindResp;
 import com.cloudhopper.smpp.tlv.Tlv;
 import org.junit.*;
 import org.jboss.netty.buffer.ChannelBuffer;
@@ -1243,6 +1226,90 @@ public class PduDecoderTest {
         Assert.assertArrayEquals("Test".getBytes("ISO-8859-1"), tlv0.getValue());
 
         // interesting -- this example has optional parameters it happened to skip...
+        Assert.assertEquals(0, buffer.readableBytes());
+    }
+
+
+    @Test
+    public void decodeCancelSm() throws Exception {
+        ChannelBuffer buffer = BufferHelper.createBuffer("0000002D000000080000000000004FE80031323334350001013430343034000101343439353133363139323000");
+
+        CancelSm pdu0 = (CancelSm)transcoder.decode(buffer);
+
+        Assert.assertEquals(45, pdu0.getCommandLength());
+        Assert.assertEquals(SmppConstants.CMD_ID_CANCEL_SM, pdu0.getCommandId());
+        Assert.assertEquals(0, pdu0.getCommandStatus());
+        Assert.assertEquals(20456, pdu0.getSequenceNumber());
+        Assert.assertEquals(true, pdu0.isRequest());
+        Assert.assertEquals("", pdu0.getServiceType());
+        Assert.assertEquals(0x01, pdu0.getSourceAddress().getTon());
+        Assert.assertEquals(0x01, pdu0.getSourceAddress().getNpi());
+        Assert.assertEquals("40404", pdu0.getSourceAddress().getAddress());
+        Assert.assertEquals(0x01, pdu0.getDestAddress().getTon());
+        Assert.assertEquals(0x01, pdu0.getDestAddress().getNpi());
+        Assert.assertEquals("44951361920", pdu0.getDestAddress().getAddress());
+        Assert.assertEquals("12345", pdu0.getMessageId());
+
+        Assert.assertEquals(null, pdu0.getOptionalParameters());
+
+        // interesting -- this example has optional parameters it happened to skip...
+        Assert.assertEquals(0, buffer.readableBytes());
+    }
+
+
+    @Test
+    public void decodeQuerySm() throws Exception {
+        ChannelBuffer buffer = BufferHelper.createBuffer("0000001E000000030000000000004FE83132333435000101343034303400");
+
+        QuerySm pdu0 = (QuerySm)transcoder.decode(buffer);
+
+        Assert.assertEquals(30, pdu0.getCommandLength());
+        Assert.assertEquals(SmppConstants.CMD_ID_QUERY_SM, pdu0.getCommandId());
+        Assert.assertEquals(0, pdu0.getCommandStatus());
+        Assert.assertEquals(20456, pdu0.getSequenceNumber());
+        Assert.assertEquals(true, pdu0.isRequest());
+        Assert.assertEquals(0x01, pdu0.getSourceAddress().getTon());
+        Assert.assertEquals(0x01, pdu0.getSourceAddress().getNpi());
+        Assert.assertEquals("40404", pdu0.getSourceAddress().getAddress());
+        Assert.assertEquals("12345", pdu0.getMessageId());
+
+        Assert.assertEquals(null, pdu0.getOptionalParameters());
+
+        // interesting -- this example has optional parameters it happened to skip...
+        Assert.assertEquals(0, buffer.readableBytes());
+    }
+
+    @Test
+    public void decodeCancelSmResp() throws Exception {
+        ChannelBuffer buffer = BufferHelper.createBuffer("00000010800000080000000000004FE8");
+
+        CancelSmResp pdu0 = (CancelSmResp)transcoder.decode(buffer);
+
+        Assert.assertEquals(16, pdu0.getCommandLength());
+        Assert.assertEquals(SmppConstants.CMD_ID_CANCEL_SM_RESP, pdu0.getCommandId());
+        Assert.assertEquals(0, pdu0.getCommandStatus());
+        Assert.assertEquals(20456, pdu0.getSequenceNumber());
+        Assert.assertEquals(true, pdu0.isResponse());
+
+        Assert.assertEquals(0, buffer.readableBytes());
+    }
+
+    @Test
+    public void decodeQuerySmResp() throws Exception {
+        ChannelBuffer buffer = BufferHelper.createBuffer("00000019800000030000000000004FE8313233343500000600");
+
+        QuerySmResp pdu0 = (QuerySmResp)transcoder.decode(buffer);
+
+        Assert.assertEquals(25, pdu0.getCommandLength());
+        Assert.assertEquals(SmppConstants.CMD_ID_QUERY_SM_RESP, pdu0.getCommandId());
+        Assert.assertEquals(0, pdu0.getCommandStatus());
+        Assert.assertEquals(20456, pdu0.getSequenceNumber());
+        Assert.assertEquals("12345", pdu0.getMessageId());
+        Assert.assertEquals("", pdu0.getFinalDate());
+        Assert.assertEquals((byte)0x06, pdu0.getMessageState());
+        Assert.assertEquals((byte)0x00, pdu0.getErrorCode());
+        Assert.assertEquals(true, pdu0.isResponse());
+
         Assert.assertEquals(0, buffer.readableBytes());
     }
 }

--- a/src/test/java/com/cloudhopper/smpp/transcoder/PduEncoderTest.java
+++ b/src/test/java/com/cloudhopper/smpp/transcoder/PduEncoderTest.java
@@ -22,27 +22,10 @@ package com.cloudhopper.smpp.transcoder;
 
 // third party imports
 import com.cloudhopper.commons.util.HexString;
+import com.cloudhopper.smpp.pdu.*;
 import com.cloudhopper.smpp.type.Address;
 import com.cloudhopper.commons.util.HexUtil;
 import com.cloudhopper.smpp.SmppConstants;
-import com.cloudhopper.smpp.pdu.BindReceiver;
-import com.cloudhopper.smpp.pdu.BindReceiverResp;
-import com.cloudhopper.smpp.pdu.BindTransceiver;
-import com.cloudhopper.smpp.pdu.BindTransceiverResp;
-import com.cloudhopper.smpp.pdu.BindTransmitter;
-import com.cloudhopper.smpp.pdu.BindTransmitterResp;
-import com.cloudhopper.smpp.pdu.BufferHelper;
-import com.cloudhopper.smpp.pdu.DataSm;
-import com.cloudhopper.smpp.pdu.DataSmResp;
-import com.cloudhopper.smpp.pdu.DeliverSm;
-import com.cloudhopper.smpp.pdu.DeliverSmResp;
-import com.cloudhopper.smpp.pdu.EnquireLink;
-import com.cloudhopper.smpp.pdu.EnquireLinkResp;
-import com.cloudhopper.smpp.pdu.GenericNack;
-import com.cloudhopper.smpp.pdu.SubmitSm;
-import com.cloudhopper.smpp.pdu.SubmitSmResp;
-import com.cloudhopper.smpp.pdu.Unbind;
-import com.cloudhopper.smpp.pdu.UnbindResp;
 import com.cloudhopper.smpp.tlv.Tlv;
 import com.cloudhopper.smpp.type.SmppInvalidArgumentException;
 import java.io.UnsupportedEncodingException;
@@ -431,5 +414,72 @@ public class PduEncoderTest {
         String actualHex = HexUtil.toHexString(BufferHelper.createByteArray(buffer)).toUpperCase();
         
         Assert.assertEquals(expectedHex, actualHex);
+    }
+
+    @Test
+    public void encodeCancelSm() throws Exception {
+        CancelSm pdu0 = new CancelSm();
+
+        pdu0.setSequenceNumber(20456);
+        pdu0.setSourceAddress(new Address((byte)0x01, (byte)0x01, "40404"));
+        pdu0.setDestAddress(new Address((byte)0x01, (byte)0x01, "44951361920"));
+        pdu0.setMessageId("12345");
+
+        ChannelBuffer buffer = transcoder.encode(pdu0);
+//        logger.debug("{}", HexUtil.toHexString(BufferHelper.createByteArray(buffer)));
+        Assert.assertArrayEquals(HexUtil.toByteArray("0000002D000000080000000000004FE80031323334350001013430343034000101343439353133363139323000"), BufferHelper.createByteArray(buffer));
+    }
+
+    @Test
+    public void encodeCancelSmResp() throws Exception {
+        CancelSmResp pdu0 = new CancelSmResp();
+
+        pdu0.setSequenceNumber(20456);
+        pdu0.setCommandStatus((byte)0x00);
+
+        ChannelBuffer buffer = transcoder.encode(pdu0);
+//        logger.debug("{}", HexUtil.toHexString(BufferHelper.createByteArray(buffer)));
+        Assert.assertArrayEquals(HexUtil.toByteArray("00000010800000080000000000004FE8"), BufferHelper.createByteArray(buffer));
+    }
+
+    @Test
+    public void encodeCancelSmRespStatusFailed() throws Exception {
+        CancelSmResp pdu0 = new CancelSmResp();
+
+        pdu0.setSequenceNumber(20456);
+        pdu0.setCommandStatus((byte)0x11);
+
+        ChannelBuffer buffer = transcoder.encode(pdu0);
+//        logger.debug("{}", HexUtil.toHexString(BufferHelper.createByteArray(buffer)));
+        Assert.assertArrayEquals(HexUtil.toByteArray("00000010800000080000001100004FE8"), BufferHelper.createByteArray(buffer));
+    }
+
+
+    @Test
+    public void encodeQuerySm() throws Exception {
+        QuerySm pdu0 = new QuerySm();
+
+        pdu0.setSequenceNumber(20456);
+        pdu0.setSourceAddress(new Address((byte)0x01, (byte)0x01, "40404"));
+        pdu0.setMessageId("12345");
+
+        ChannelBuffer buffer = transcoder.encode(pdu0);
+//        logger.debug("{}", HexUtil.toHexString(BufferHelper.createByteArray(buffer)));
+        Assert.assertArrayEquals(HexUtil.toByteArray("0000001E000000030000000000004FE83132333435000101343034303400"), BufferHelper.createByteArray(buffer));
+    }
+
+    @Test
+    public void encodeQueryRespSm() throws Exception {
+        QuerySmResp pdu0 = new QuerySmResp();
+
+        pdu0.setSequenceNumber(20456);
+        pdu0.setMessageId("12345");
+        pdu0.setMessageState((byte)0x06);
+        pdu0.setFinalDate(null);
+        pdu0.setErrorCode((byte)0x00);
+
+        ChannelBuffer buffer = transcoder.encode(pdu0);
+//        logger.debug("{}", HexUtil.toHexString(BufferHelper.createByteArray(buffer)));
+        Assert.assertArrayEquals(HexUtil.toByteArray("00000019800000030000000000004FE8313233343500000600"), BufferHelper.createByteArray(buffer));
     }
 }


### PR DESCRIPTION
Tested against our SMPP gateway provider; no obvious errors returned, but they also don't support these two commands.
