### PR TITLE
fix (and test) for encoding submit_sm_resp messages with no message_id

### DIFF
--- a/src/main/java/com/cloudhopper/smpp/pdu/BaseSmResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/BaseSmResp.java
@@ -63,7 +63,14 @@ public abstract class BaseSmResp extends PduResponse {
 
     @Override
     public void writeBody(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
-        ChannelBufferUtil.writeNullTerminatedString(buffer, this.messageId);
+        // when this PDU was parsed, it's possible it was missing the messageId instead
+        // of having a NULL messageId. If that's the case, the commandLength will be just
+        // enough for the headers (and theoretically any optional TLVs). Don't try to
+        // write the NULL byte for that case.
+        // See special note in 4.4.2 of SMPP 3.4 spec
+        if (!((buffer.writableBytes() == 0) && (this.messageId == null))) {
+            ChannelBufferUtil.writeNullTerminatedString(buffer, this.messageId);
+        }
     }
 
     @Override

--- a/src/test/java/com/cloudhopper/smpp/transcoder/PduEncoderTest.java
+++ b/src/test/java/com/cloudhopper/smpp/transcoder/PduEncoderTest.java
@@ -82,12 +82,23 @@ public class PduEncoderTest {
     }
 
     @Test
-    public void encodeSubmitSmRespWithNoMessageId() throws Exception {
+    public void encodeSubmitSmRespWithNullMessageId() throws Exception {
         SubmitSmResp pdu0 = new SubmitSmResp();
         pdu0.setSequenceNumber(171192033);
 
         ChannelBuffer buffer = transcoder.encode(pdu0);
         Assert.assertArrayEquals(HexUtil.toByteArray("0000001180000004000000000a342ee100"), BufferHelper.createByteArray(buffer));
+    }
+
+    @Test
+    public void encodeSubmitSmRespWithOmittedMesageId() throws Exception {
+        SubmitSmResp pdu0 = new SubmitSmResp();
+        pdu0.setSequenceNumber(171192033);
+        pdu0.setCommandStatus(0x30);
+        pdu0.setCommandLength(16);
+
+        ChannelBuffer buffer = transcoder.encode(pdu0);
+        Assert.assertArrayEquals(HexUtil.toByteArray("0000001080000004000000300a342ee1"), BufferHelper.createByteArray(buffer));
     }
 
     @Test


### PR DESCRIPTION
Working with a provider who leaves off the message_id in error submit_sm_resp, I noticed that the PDUEncoder was throwing a ArrayIndexOutOfBounds exception when trying to append a \0 byte to the buffer.

Digging deeper, it seems this is actually acceptable behavior according to SMPP 3.4 (but not 3.3 or 5.0):

http://en.wikipedia.org/wiki/Short_Message_Peer-to-Peer#submit_sm_resp_incompatibility_between_SMPP_versions

It seems like some places in the code already account for this ambiguity, but the PDUEncoder did not.

There is one edge case this fix does not cover, but I do not think it is important. Consider a submit_sm_resp with a non-0 status, an omitted message_id, and the existence of optional parameters.  In this situation, I maintain that it's not always possible to disambiguate between when the message_id null-terminated-string ends and when the optional parameters begin; it seems like an oversight of the 3.4 spec.
