### PR TITLE
Modifications for DeliveryReceipt to take into account that err token is...

### DIFF
--- a/src/main/java/com/cloudhopper/smpp/util/DeliveryReceipt.java
+++ b/src/main/java/com/cloudhopper/smpp/util/DeliveryReceipt.java
@@ -69,7 +69,7 @@ public class DeliveryReceipt {
     // field "stat": final state of message
     private byte state;
     // field "err": network/smsc specific error code
-    private int errorCode;
+    private String errorCode;
     // field "text": first 20 characters of original message
     private String text;
 
@@ -77,7 +77,7 @@ public class DeliveryReceipt {
         // do nothing
     }
 
-    public DeliveryReceipt(String messageId, int submitCount, int deliveredCount, DateTime submitDate, DateTime doneDate, byte state, int errorCode, String text) {
+    public DeliveryReceipt(String messageId, int submitCount, int deliveredCount, DateTime submitDate, DateTime doneDate, byte state, String errorCode, String text) {
         this.messageId = messageId;
         this.submitCount = submitCount;
         this.deliveredCount = deliveredCount;
@@ -96,11 +96,11 @@ public class DeliveryReceipt {
         this.deliveredCount = deliveredCount;
     }
 
-    public int getErrorCode() {
+    public String getErrorCode() {
         return errorCode;
     }
 
-    public void setErrorCode(int errorCode) {
+    public void setErrorCode(String errorCode) {
         this.errorCode = errorCode;
     }
 
@@ -199,7 +199,7 @@ public class DeliveryReceipt {
         buf.append(toStateText(this.state));
         buf.append(" ");
         buf.append(FIELD_ERR);
-        buf.append(String.format("%03d", this.errorCode));
+        buf.append(this.errorCode);
         buf.append(" ");
         buf.append(FIELD_TEXT);
         if (this.text != null) {
@@ -277,7 +277,7 @@ public class DeliveryReceipt {
         String normalizedText = shortMessage.toLowerCase();
 
         // create a new DLR with fields set to "uninitialized" values
-        DeliveryReceipt dlr = new DeliveryReceipt(null, -1, -1, null, null, (byte)-1, -1, null);
+        DeliveryReceipt dlr = new DeliveryReceipt(null, -1, -1, null, null, (byte)-1, null, null);
         TreeMap<Integer,String> fieldsByStartPos = new TreeMap<Integer,String>();
 
         // find location of all possible fields in text of message and add to
@@ -343,7 +343,7 @@ public class DeliveryReceipt {
                     }
                 } else if (fieldLabel.equalsIgnoreCase(FIELD_ERR)) {
                     try {
-                        dlr.errorCode = Integer.parseInt(fieldValue);
+                        dlr.errorCode = fieldValue;
                     } catch (NumberFormatException e) {
                         throw new DeliveryReceiptException("Unable to convert [err] field with value [" + fieldValue + "] into an integer");
                     }
@@ -382,7 +382,7 @@ public class DeliveryReceipt {
                 throw new DeliveryReceiptException("Unable to find [stat] field or empty value in delivery receipt message");
             }
 
-            if (dlr.errorCode < 0) {
+            if (StringUtil.isEmpty(dlr.errorCode)) {
                 throw new DeliveryReceiptException("Unable to find [err] field or empty value in delivery receipt message");
             }
         }

--- a/src/main/java/com/cloudhopper/smpp/util/DeliveryReceipt.java
+++ b/src/main/java/com/cloudhopper/smpp/util/DeliveryReceipt.java
@@ -55,6 +55,8 @@ public class DeliveryReceipt {
     public static final String FIELD_STAT = "stat:";
     public static final String FIELD_ERR = "err:";
     public static final String FIELD_TEXT = "text:";
+    
+    public static final int FIELD_ERR_MAX_LEN = 3;
 
     // field "id": id of message originally submitted
     private String messageId;
@@ -84,7 +86,7 @@ public class DeliveryReceipt {
         this.submitDate = submitDate;
         this.doneDate = doneDate;
         this.state = state;
-        this.errorCode = errorCode;
+        setErrorCode(errorCode);
         this.text = text;
     }
 
@@ -101,7 +103,10 @@ public class DeliveryReceipt {
     }
 
     public void setErrorCode(String errorCode) {
-        this.errorCode = errorCode;
+    	if ( errorCode.length() <= FIELD_ERR_MAX_LEN )
+    		this.errorCode = errorCode;
+    	else
+    		throw new RuntimeException(String.format("Error code cannnot be greater than %d", FIELD_ERR_MAX_LEN));
     }
 
     public DateTime getDoneDate() {

--- a/src/test/java/com/cloudhopper/smpp/util/DeliveryReceiptTest.java
+++ b/src/test/java/com/cloudhopper/smpp/util/DeliveryReceiptTest.java
@@ -54,18 +54,18 @@ public class DeliveryReceiptTest {
         dlr.setSubmitDate(new DateTime(2010, 5, 23, 20, 39, 0, 0, DateTimeZone.UTC));
         dlr.setDoneDate(new DateTime(2010, 5, 24, 23, 39, 0, 0, DateTimeZone.UTC));
         dlr.setState(SmppConstants.STATE_DELIVERED);
-        dlr.setErrorCode(12);
+        dlr.setErrorCode(Integer.toString(12));
         dlr.setText("This is a sample message that I want to have added to the delivery receipt");
 
         String receipt0 = dlr.toShortMessage();
 
         //logger.debug(receipt0);
-        Assert.assertEquals("id:0123456789 sub:001 dlvrd:001 submit date:1005232039 done date:1005242339 stat:DELIVRD err:012 text:This is a sample mes", receipt0);
+        Assert.assertEquals("id:0123456789 sub:001 dlvrd:001 submit date:1005232039 done date:1005242339 stat:DELIVRD err:12 text:This is a sample mes", receipt0);
     }
 
     @Test
     public void parseShortMessage() throws Exception {
-        String receipt0 = "id:0123456789 sub:002 dlvrd:001 submit date:1005232039 done date:1005242339 stat:DELIVRD err:012 text:This is a sample mes";
+        String receipt0 = "id:0123456789 sub:002 dlvrd:001 submit date:1005232039 done date:1005242339 stat:DELIVRD err:12 text:This is a sample mes";
 
         DeliveryReceipt dlr = DeliveryReceipt.parseShortMessage(receipt0, DateTimeZone.UTC);
 
@@ -75,7 +75,7 @@ public class DeliveryReceiptTest {
         Assert.assertEquals(new DateTime(2010, 5, 23, 20, 39, 0, 0, DateTimeZone.UTC), dlr.getSubmitDate());
         Assert.assertEquals(new DateTime(2010, 5, 24, 23, 39, 0, 0, DateTimeZone.UTC), dlr.getDoneDate());
         Assert.assertEquals(SmppConstants.STATE_DELIVERED, dlr.getState());
-        Assert.assertEquals(12, dlr.getErrorCode());
+        Assert.assertEquals("12", dlr.getErrorCode());
         Assert.assertEquals("This is a sample mes", dlr.getText());
 
 
@@ -89,7 +89,7 @@ public class DeliveryReceiptTest {
         Assert.assertEquals(new DateTime(2010, 6, 2, 0, 51, 0, 0, DateTimeZone.UTC), dlr.getSubmitDate());
         Assert.assertEquals(new DateTime(2010, 6, 2, 0, 51, 0, 0, DateTimeZone.UTC), dlr.getDoneDate());
         Assert.assertEquals(SmppConstants.STATE_DELIVERED, dlr.getState());
-        Assert.assertEquals(0, dlr.getErrorCode());
+        Assert.assertEquals("000", dlr.getErrorCode());
         Assert.assertEquals("Hello", dlr.getText());
     }
 
@@ -203,7 +203,7 @@ public class DeliveryReceiptTest {
         Assert.assertEquals(new DateTime(2011, 2, 6, 19, 30, 41, 0, DateTimeZone.UTC), dlr.getSubmitDate());
         Assert.assertEquals(new DateTime(2011, 2, 6, 19, 31, 10, 0, DateTimeZone.UTC), dlr.getDoneDate());
         Assert.assertEquals(SmppConstants.STATE_DELIVERED, dlr.getState());
-        Assert.assertEquals(0, dlr.getErrorCode());
+        Assert.assertEquals("000", dlr.getErrorCode());
         Assert.assertNull(dlr.getText());
     }
 
@@ -218,7 +218,7 @@ public class DeliveryReceiptTest {
         Assert.assertEquals(new DateTime(2011, 2, 6, 19, 30, 41, 0, DateTimeZone.UTC), dlr.getSubmitDate());
         Assert.assertEquals(new DateTime(2011, 2, 6, 19, 31, 10, 0, DateTimeZone.UTC), dlr.getDoneDate());
         Assert.assertEquals(SmppConstants.STATE_DELIVERED, dlr.getState());
-        Assert.assertEquals(0, dlr.getErrorCode());
+        Assert.assertEquals("000", dlr.getErrorCode());
         Assert.assertNull(dlr.getText());
     }
 
@@ -322,7 +322,7 @@ public class DeliveryReceiptTest {
         Assert.assertEquals(new DateTime(2011, 3, 14, 18, 15, 34, 0, DateTimeZone.UTC), dlr.getSubmitDate());
         Assert.assertEquals(new DateTime(2011, 3, 14, 18, 17, 41, 0, DateTimeZone.UTC), dlr.getDoneDate());
         Assert.assertEquals(SmppConstants.STATE_DELIVERED, dlr.getState());
-        Assert.assertEquals(0, dlr.getErrorCode());
+        Assert.assertEquals("000", dlr.getErrorCode());
         Assert.assertNull(dlr.getText());
     }
 }


### PR DESCRIPTION
The smpp spec states that the err token is a length 3 c-octet string.  The DeliveryReceipt class was parsing as an int.  I've updated the logic and the test to support a String (this should perhaps validate length and limit to 3).
