### PR TITLE
DeliveryReceipt.toShortMessage() broken doneDate null-check #55

### DIFF
--- a/src/main/java/com/cloudhopper/smpp/util/DeliveryReceipt.java
+++ b/src/main/java/com/cloudhopper/smpp/util/DeliveryReceipt.java
@@ -245,7 +245,7 @@ public class DeliveryReceipt {
 		}
 		buf.append(" ");
 		buf.append(FIELD_DONE_DATE);
-		if (this.submitDate == null) {
+		if (this.doneDate == null) {
 			buf.append("0000000000");
 		} else {
 			buf.append(dateFormatTemplate.print(this.doneDate));


### PR DESCRIPTION
This is just a fix for the null-check of the wrong field including a test case, not changing anything related to other fields though here.
