### PR TITLE
Low-level PDU listener

### DIFF
--- a/src/main/java/com/cloudhopper/smpp/SmppSessionListener.java
+++ b/src/main/java/com/cloudhopper/smpp/SmppSessionListener.java
@@ -1,0 +1,54 @@
+package com.cloudhopper.smpp;
+
+/*
+ * #%L
+ * ch-smpp
+ * %%
+ * Copyright (C) 2009 - 2014 Cloudhopper by Twitter
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.cloudhopper.smpp.pdu.Pdu;
+
+/**
+ * Low-level PDU traffic listener. 
+ * Could be used for PDU filtering.
+ * Use with caution.
+ *
+ * @author t3hk0d3
+ */
+public interface SmppSessionListener extends SmppSessionHandler {
+    
+    /**
+     * Called when ANY PDU received from connection.
+     * This method could be used to sniff all incoming SMPP packet traffic,
+     * and also permit/deny it from futher processing.
+     * Could be used for advanced packet logging, counters and filtering.
+     * @param pdu 
+     * @return boolean allow PDU processing. If false PDU would be discarded.
+     */
+    public boolean firePduRecived(Pdu pdu);
+    
+    /**
+     * Called when ANY PDU received from connection.
+     * This method could be used to sniff all outgoing SMPP packet traffic,
+     * and also permit/deny it from sending.
+     * Could be used for advanced packet logging, counters and filtering.
+     * @param pdu 
+     * @return boolean allow PDU sending. If false PDU would be discarded.
+     */
+    public boolean firePduDispatch(Pdu pdu);
+    
+}

--- a/src/main/java/com/cloudhopper/smpp/impl/DefaultSmppSession.java
+++ b/src/main/java/com/cloudhopper/smpp/impl/DefaultSmppSession.java
@@ -34,6 +34,7 @@ import com.cloudhopper.smpp.type.SmppChannelException;
 import com.cloudhopper.smpp.SmppSessionConfiguration;
 import com.cloudhopper.smpp.SmppSessionCounters;
 import com.cloudhopper.smpp.SmppSessionHandler;
+import com.cloudhopper.smpp.SmppSessionListener;
 import com.cloudhopper.smpp.type.SmppTimeoutException;
 import com.cloudhopper.smpp.pdu.BaseBind;
 import com.cloudhopper.smpp.pdu.BaseBindResp;
@@ -506,6 +507,14 @@ public class DefaultSmppSession implements SmppServerSession, SmppSessionChannel
         } catch (OfferTimeoutException e) {
             throw new SmppTimeoutException(e.getMessage(), e);
         }
+        
+        if(this.sessionHandler instanceof SmppSessionListener) {
+            if(!((SmppSessionListener)this.sessionHandler).firePduDispatch(pdu)) {
+                logger.info("dispatched request PDU discarded: {}", pdu);
+                future.cancel(); //@todo probably throwing exception here is better solution?
+                return future;
+            }
+        }
 
         // we need to log the PDU after encoding since some things only happen
         // during the encoding process such as looking up the result message
@@ -546,6 +555,13 @@ public class DefaultSmppSession implements SmppServerSession, SmppSessionChannel
         if (!pdu.hasSequenceNumberAssigned()) {
             pdu.setSequenceNumber(this.sequenceNumber.next());
         }
+        
+        if(this.sessionHandler instanceof SmppSessionListener) {
+            if(!((SmppSessionListener)this.sessionHandler).firePduDispatch(pdu)) {
+                logger.info("dispatched response PDU discarded: {}", pdu);
+                return;
+            }
+        }
 
         // encode the pdu into a buffer
         ChannelBuffer buffer = transcoder.encode(pdu);
@@ -571,6 +587,13 @@ public class DefaultSmppSession implements SmppServerSession, SmppSessionChannel
     public void firePduReceived(Pdu pdu) {
         if (configuration.getLoggingOptions().isLogPduEnabled()) {
             logger.info("received PDU: {}", pdu);
+        }
+
+        if(this.sessionHandler instanceof SmppSessionListener) {
+            if(!((SmppSessionListener)this.sessionHandler).firePduRecived(pdu)){
+                logger.info("recieved PDU discarded: {}", pdu);
+                return;
+            }
         }
 
         if (pdu instanceof PduRequest) {

--- a/src/main/java/com/cloudhopper/smpp/impl/DefaultSmppSessionHandler.java
+++ b/src/main/java/com/cloudhopper/smpp/impl/DefaultSmppSessionHandler.java
@@ -22,6 +22,8 @@ package com.cloudhopper.smpp.impl;
 
 import com.cloudhopper.smpp.PduAsyncResponse;
 import com.cloudhopper.smpp.SmppSessionHandler;
+import com.cloudhopper.smpp.SmppSessionListener;
+import com.cloudhopper.smpp.pdu.Pdu;
 import com.cloudhopper.smpp.pdu.PduRequest;
 import com.cloudhopper.smpp.pdu.PduResponse;
 import com.cloudhopper.smpp.type.RecoverablePduException;
@@ -37,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * 
  * @author joelauer (twitter: @jjlauer or <a href="http://twitter.com/jjlauer" target=window>http://twitter.com/jjlauer</a>)
  */
-public class DefaultSmppSessionHandler implements SmppSessionHandler {
+public class DefaultSmppSessionHandler implements SmppSessionListener {
     private final Logger logger;
 
     public DefaultSmppSessionHandler() {
@@ -102,6 +104,16 @@ public class DefaultSmppSessionHandler implements SmppSessionHandler {
     @Override
     public void firePduRequestExpired(PduRequest pduRequest) {
         logger.warn("Default handling is to discard expired request PDU: {}", pduRequest);
+    }
+
+    @Override
+    public boolean firePduRecived(Pdu pdu) {
+        return true;
+    }
+
+    @Override
+    public boolean firePduDispatch(Pdu pdu) {
+        return true;
     }
     
 }


### PR DESCRIPTION
I've met task where i have to send enquire link request only after specified time from any last PDU received.
There is only way with overriding `DefaultSMPPSession` and `DefaultSMPPClient`, hooking up to `firePduReceived` method, because `SmppSessionHandler` misses PDU's sent through `WindowFuture`.

So i came with solution for low-level hooks for PDU being received or sent.
Bonus is you can discard received/sent PDU from further processing/dispatching.

For example this would be handy if you have your own PDU processing pipeline.
