### PR TITLE
Submit_multi operation implementation (SMPP 3.4 section 4.5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ target/
 .classpath
 .project
 .settings/
-
+.idea/
+*.iml

--- a/src/main/java/com/cloudhopper/smpp/pdu/BaseSm.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/BaseSm.java
@@ -173,7 +173,7 @@ public abstract class BaseSm<R extends PduResponse> extends PduRequest<R> {
     public void readBody(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
         this.serviceType = ChannelBufferUtil.readNullTerminatedString(buffer);
         this.sourceAddress = ChannelBufferUtil.readAddress(buffer);
-        this.destAddress = ChannelBufferUtil.readAddress(buffer);
+        readDestinationAddress(buffer);
         this.esmClass = buffer.readByte();
         this.protocolId = buffer.readByte();
         this.priority = buffer.readByte();
@@ -194,7 +194,7 @@ public abstract class BaseSm<R extends PduResponse> extends PduRequest<R> {
         int bodyLength = 0;
         bodyLength += PduUtil.calculateByteSizeOfNullTerminatedString(this.serviceType);
         bodyLength += PduUtil.calculateByteSizeOfAddress(this.sourceAddress);
-        bodyLength += PduUtil.calculateByteSizeOfAddress(this.destAddress);
+        bodyLength += calculateDestinationAddressSize();
         bodyLength += 3;    // esmClass, priority, protocolId
         bodyLength += PduUtil.calculateByteSizeOfNullTerminatedString(this.scheduleDeliveryTime);
         bodyLength += PduUtil.calculateByteSizeOfNullTerminatedString(this.validityPeriod);
@@ -207,7 +207,7 @@ public abstract class BaseSm<R extends PduResponse> extends PduRequest<R> {
     public void writeBody(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
         ChannelBufferUtil.writeNullTerminatedString(buffer, this.serviceType);
         ChannelBufferUtil.writeAddress(buffer, this.sourceAddress);
-        ChannelBufferUtil.writeAddress(buffer, this.destAddress);
+        writeDestinationAddress(buffer);
         buffer.writeByte(this.esmClass);
         buffer.writeByte(this.protocolId);
         buffer.writeByte(this.priority);
@@ -229,8 +229,7 @@ public abstract class BaseSm<R extends PduResponse> extends PduRequest<R> {
         buffer.append(StringUtil.toStringWithNullAsEmpty(this.serviceType));
         buffer.append("] sourceAddr [");
         buffer.append(StringUtil.toStringWithNullAsEmpty(this.sourceAddress));
-        buffer.append("] destAddr [");
-        buffer.append(StringUtil.toStringWithNullAsEmpty(this.destAddress));
+        appendDestinationAddressToString(buffer);
 
         buffer.append("] esmCls [0x");
         buffer.append(HexUtil.toHexString(this.esmClass));
@@ -242,5 +241,22 @@ public abstract class BaseSm<R extends PduResponse> extends PduRequest<R> {
         buffer.append("] message [");
         HexUtil.appendHexString(buffer, this.shortMessage);
         buffer.append("])");
+    }
+
+    protected void readDestinationAddress(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
+        this.destAddress = ChannelBufferUtil.readAddress(buffer);
+    }
+
+    protected void writeDestinationAddress(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
+        ChannelBufferUtil.writeAddress(buffer, this.destAddress);
+    }
+
+    protected int calculateDestinationAddressSize() {
+        return PduUtil.calculateByteSizeOfAddress(this.destAddress);
+    }
+
+    protected void appendDestinationAddressToString(StringBuilder buffer) {
+        buffer.append("] destAddr [");
+        buffer.append(StringUtil.toStringWithNullAsEmpty(this.destAddress));
     }
 }

--- a/src/main/java/com/cloudhopper/smpp/pdu/SubmitMulti.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/SubmitMulti.java
@@ -1,0 +1,105 @@
+package com.cloudhopper.smpp.pdu;
+
+/*
+ * #%L
+ * ch-smpp
+ * %%
+ * Copyright (C) 2009 - 2012 Cloudhopper by Twitter
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.cloudhopper.commons.util.StringUtil;
+import com.cloudhopper.smpp.SmppConstants;
+import com.cloudhopper.smpp.type.RecoverablePduException;
+import com.cloudhopper.smpp.type.SubmitMultiDestinationAddress;
+import com.cloudhopper.smpp.type.UnrecoverablePduException;
+import com.cloudhopper.smpp.util.ChannelBufferUtil;
+import com.cloudhopper.smpp.util.PduUtil;
+import org.jboss.netty.buffer.ChannelBuffer;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * @author innar.made@ishisystems.com
+ */
+public class SubmitMulti extends BaseSm<SubmitMultiResp> {
+
+    private List<SubmitMultiDestinationAddress> submitMultiDestinationAddressList;
+
+    public SubmitMulti() {
+        super(SmppConstants.CMD_ID_SUBMIT_MULTI, "submit_multi");
+    }
+
+    public List<SubmitMultiDestinationAddress> getSubmitMultiDestinationAddressList() {
+        return this.submitMultiDestinationAddressList;
+    }
+
+    public void setSubmitMultiDestinationAddressList(List<SubmitMultiDestinationAddress> addressList) {
+        this.submitMultiDestinationAddressList = addressList;
+    }
+
+    public int getNumberOfDestinations() {
+        return submitMultiDestinationAddressList == null ? 0 : submitMultiDestinationAddressList.size();
+    }
+
+    @Override
+    public SubmitMultiResp createResponse() {
+        SubmitMultiResp resp = new SubmitMultiResp();
+        resp.setSequenceNumber(this.getSequenceNumber());
+        return resp;
+    }
+
+    @Override
+    public Class<SubmitMultiResp> getResponseClass() {
+        return SubmitMultiResp.class;
+    }
+
+    @Override
+    protected void readDestinationAddress(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
+        submitMultiDestinationAddressList = ChannelBufferUtil.readSubmitMultiAddressList(buffer);
+    }
+
+    @Override
+    protected void writeDestinationAddress(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
+        ChannelBufferUtil.writeSubmitMultiAddressList(buffer, submitMultiDestinationAddressList);
+    }
+
+    @Override
+    protected int calculateDestinationAddressSize() {
+        return PduUtil.calculateByteSizeOfSubmitMultiAddressList(submitMultiDestinationAddressList);
+    }
+
+    @Override
+    protected void appendDestinationAddressToString(StringBuilder buffer) {
+        appendSubmitMultiDestinationAddressList(buffer);
+    }
+
+    private void appendSubmitMultiDestinationAddressList(StringBuilder buffer) {
+        int numberOfDestinations = getNumberOfDestinations();
+        buffer.append("] number_of_dests [").append(numberOfDestinations);
+        buffer.append("] dest_addresses [");
+        if (numberOfDestinations > 0) {
+            Iterator<SubmitMultiDestinationAddress> iterator = getSubmitMultiDestinationAddressList().iterator();
+            while (iterator.hasNext()) {
+                SubmitMultiDestinationAddress address = iterator.next();
+                buffer.append("(").append(StringUtil.toStringWithNullAsEmpty(address)).append(")");
+                if (iterator.hasNext()) {
+                    buffer.append(",");
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/cloudhopper/smpp/pdu/SubmitMultiResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/SubmitMultiResp.java
@@ -1,0 +1,99 @@
+package com.cloudhopper.smpp.pdu;
+
+/*
+ * #%L
+ * ch-smpp
+ * %%
+ * Copyright (C) 2009 - 2012 Cloudhopper by Twitter
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.cloudhopper.commons.util.StringUtil;
+import com.cloudhopper.smpp.SmppConstants;
+import com.cloudhopper.smpp.type.RecoverablePduException;
+import com.cloudhopper.smpp.type.SubmitMultiUnsuccessSme;
+import com.cloudhopper.smpp.type.UnrecoverablePduException;
+import com.cloudhopper.smpp.util.ChannelBufferUtil;
+import com.cloudhopper.smpp.util.PduUtil;
+import org.jboss.netty.buffer.ChannelBuffer;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * @author innar.made@ishisystems.com
+ */
+public class SubmitMultiResp extends BaseSmResp {
+
+    private List<SubmitMultiUnsuccessSme> unsuccessSmes;
+
+    public SubmitMultiResp() {
+        super(SmppConstants.CMD_ID_SUBMIT_MULTI_RESP, "submit_multi_resp");
+    }
+
+    public int getNumberOfUnsuccessSmes() {
+        if (unsuccessSmes == null || unsuccessSmes.isEmpty()) {
+            return 0;
+        }
+        return unsuccessSmes.size();
+    }
+
+    public List<SubmitMultiUnsuccessSme> getUnsuccessSmes() {
+        return unsuccessSmes;
+    }
+
+    public void setUnsuccessSmes(List<SubmitMultiUnsuccessSme> unsuccessSmes) {
+        this.unsuccessSmes = unsuccessSmes;
+    }
+
+    @Override
+    public void readBody(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
+        super.readBody(buffer);
+        unsuccessSmes = ChannelBufferUtil.readSubmitMultiUnsuccessSmeList(buffer);
+    }
+
+    @Override
+    public int calculateByteSizeOfBody() {
+        int bodyLength = super.calculateByteSizeOfBody();
+        bodyLength += PduUtil.calculateByteSizeOfSubmitMultiUnsucessSmeList(getUnsuccessSmes());
+        return bodyLength;
+    }
+
+    @Override
+    public void writeBody(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
+        ChannelBufferUtil.writeNullTerminatedString(buffer, getMessageId());
+        ChannelBufferUtil.writeSubmitMultiUnsuccessSmeList(buffer, getUnsuccessSmes());
+    }
+
+    @Override
+    public void appendBodyToString(StringBuilder buffer) {
+        buffer.append("(messageId [").append(StringUtil.toStringWithNullAsEmpty(getMessageId()));
+        int numberOfUnsuccessSmes = getNumberOfUnsuccessSmes();
+        buffer.append("] no_unsuccess [").append(numberOfUnsuccessSmes);
+        buffer.append("] unsuccess_smes [");
+        if (numberOfUnsuccessSmes > 0) {
+            Iterator<SubmitMultiUnsuccessSme> iterator = unsuccessSmes.iterator();
+            while (iterator.hasNext()) {
+                SubmitMultiUnsuccessSme unsuccessSme = iterator.next();
+                buffer.append(StringUtil.toStringWithNullAsNull(unsuccessSme));
+                if (iterator.hasNext()) {
+                    buffer.append(", ");
+                }
+            }
+        } else {
+            buffer.append("])");
+        }
+    }
+}

--- a/src/main/java/com/cloudhopper/smpp/transcoder/DefaultPduTranscoder.java
+++ b/src/main/java/com/cloudhopper/smpp/transcoder/DefaultPduTranscoder.java
@@ -20,36 +20,12 @@ package com.cloudhopper.smpp.transcoder;
  * #L%
  */
 
+import com.cloudhopper.smpp.pdu.*;
 import com.cloudhopper.smpp.type.UnrecoverablePduException;
 import com.cloudhopper.smpp.type.UnknownCommandIdException;
 import com.cloudhopper.smpp.type.RecoverablePduException;
 import com.cloudhopper.commons.util.HexUtil;
 import com.cloudhopper.smpp.SmppConstants;
-import com.cloudhopper.smpp.pdu.BindReceiver;
-import com.cloudhopper.smpp.pdu.BindReceiverResp;
-import com.cloudhopper.smpp.pdu.BindTransceiver;
-import com.cloudhopper.smpp.pdu.BindTransceiverResp;
-import com.cloudhopper.smpp.pdu.BindTransmitter;
-import com.cloudhopper.smpp.pdu.BindTransmitterResp;
-import com.cloudhopper.smpp.pdu.CancelSm;
-import com.cloudhopper.smpp.pdu.CancelSmResp;
-import com.cloudhopper.smpp.pdu.DataSm;
-import com.cloudhopper.smpp.pdu.DataSmResp;
-import com.cloudhopper.smpp.pdu.DeliverSm;
-import com.cloudhopper.smpp.pdu.DeliverSmResp;
-import com.cloudhopper.smpp.pdu.EnquireLink;
-import com.cloudhopper.smpp.pdu.EnquireLinkResp;
-import com.cloudhopper.smpp.pdu.GenericNack;
-import com.cloudhopper.smpp.pdu.PartialPdu;
-import com.cloudhopper.smpp.pdu.PartialPduResp;
-import com.cloudhopper.smpp.pdu.Pdu;
-import com.cloudhopper.smpp.pdu.PduResponse;
-import com.cloudhopper.smpp.pdu.QuerySm;
-import com.cloudhopper.smpp.pdu.QuerySmResp;
-import com.cloudhopper.smpp.pdu.SubmitSm;
-import com.cloudhopper.smpp.pdu.SubmitSmResp;
-import com.cloudhopper.smpp.pdu.Unbind;
-import com.cloudhopper.smpp.pdu.UnbindResp;
 import com.cloudhopper.smpp.type.NotEnoughDataInBufferException;
 import com.cloudhopper.smpp.util.PduUtil;
 import com.cloudhopper.smpp.util.SequenceNumber;
@@ -165,6 +141,8 @@ public class DefaultPduTranscoder implements PduTranscoder {
                 pdu = new CancelSm();
             } else if (commandId == SmppConstants.CMD_ID_QUERY_SM) {
                 pdu = new QuerySm();
+            } else if (commandId == SmppConstants.CMD_ID_SUBMIT_MULTI) {
+                pdu = new SubmitMulti();
             } else if (commandId == SmppConstants.CMD_ID_BIND_TRANSCEIVER) {
                 pdu = new BindTransceiver();
             } else if (commandId == SmppConstants.CMD_ID_BIND_TRANSMITTER) {
@@ -187,6 +165,8 @@ public class DefaultPduTranscoder implements PduTranscoder {
                 pdu = new CancelSmResp();
             } else if (commandId == SmppConstants.CMD_ID_QUERY_SM_RESP) {
                 pdu = new QuerySmResp();
+            } else if (commandId == SmppConstants.CMD_ID_SUBMIT_MULTI_RESP) {
+                pdu = new SubmitMultiResp();
             } else if (commandId == SmppConstants.CMD_ID_ENQUIRE_LINK_RESP) {
                 pdu = new EnquireLinkResp();
             } else if (commandId == SmppConstants.CMD_ID_BIND_TRANSCEIVER_RESP) {

--- a/src/main/java/com/cloudhopper/smpp/type/SubmitMultiDestinationAddress.java
+++ b/src/main/java/com/cloudhopper/smpp/type/SubmitMultiDestinationAddress.java
@@ -1,0 +1,131 @@
+package com.cloudhopper.smpp.type;
+
+/*
+ * #%L
+ * ch-smpp
+ * %%
+ * Copyright (C) 2009 - 2012 Cloudhopper by Twitter
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.cloudhopper.commons.util.HexUtil;
+import com.cloudhopper.commons.util.StringUtil;
+import com.cloudhopper.smpp.SmppConstants;
+import com.cloudhopper.smpp.util.ChannelBufferUtil;
+import com.cloudhopper.smpp.util.PduUtil;
+import org.jboss.netty.buffer.ChannelBuffer;
+
+/**
+ * @author innar.made@ishisystems.com
+ */
+public class SubmitMultiDestinationAddress {
+
+    protected byte destinationFlag;
+    protected Address address;
+    protected String distributionListName;
+
+    public SubmitMultiDestinationAddress() {
+    }
+
+    public SubmitMultiDestinationAddress(Address address) {
+        this.destinationFlag = SmppConstants.SM_DEST_SME_ADDRESS;
+        this.address = address;
+    }
+
+    public SubmitMultiDestinationAddress(String distributionListName) {
+        this.destinationFlag = SmppConstants.SM_DEST_DL_NAME;
+        this.distributionListName = distributionListName;
+    }
+
+    public byte getDestinationFlag() {
+        return this.destinationFlag;
+    }
+
+    public void setDestinationFlag(byte destinationFlag) {
+        this.destinationFlag = destinationFlag;
+    }
+
+    public Address getAddress() {
+        return this.address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+
+    public String getDistributionListName() {
+        return this.distributionListName;
+    }
+
+    public void setDistributionListName(String distributionListName) {
+        this.distributionListName = distributionListName;
+    }
+
+    public boolean isAddress() {
+        return this.destinationFlag == SmppConstants.SM_DEST_SME_ADDRESS;
+    }
+
+    public boolean isDistributionListName() {
+        return this.destinationFlag == SmppConstants.SM_DEST_DL_NAME;
+    }
+
+    public int calculateByteSize() {
+        int size = 1;
+        if (isAddress()) {
+            size += PduUtil.calculateByteSizeOfAddress(this.address);
+        } else if (isDistributionListName()) {
+            size += PduUtil.calculateByteSizeOfNullTerminatedString(this.distributionListName);
+        }
+        return size;
+    }
+
+    public void read(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
+        destinationFlag = buffer.readByte();
+        if (isAddress()) {
+            address = ChannelBufferUtil.readAddress(buffer);
+        } else if (isDistributionListName()) {
+            distributionListName = ChannelBufferUtil.readNullTerminatedString(buffer);
+        } else {
+            throwInvalidDestinationFlagException();
+        }
+    }
+
+    public void write(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
+        buffer.writeByte(destinationFlag);
+        if (isAddress()) {
+            ChannelBufferUtil.writeAddress(buffer, this.address);
+        } else if (isDistributionListName()) {
+            ChannelBufferUtil.writeNullTerminatedString(buffer, this.distributionListName);
+        } else {
+            throwInvalidDestinationFlagException();
+        }
+    }
+
+    protected void throwInvalidDestinationFlagException() throws SmppInvalidArgumentException {
+        String msg = "Invalid submit_multi dest_flag value %s, valid values are 1 = SME Address or 2 = Distribution List Name";
+        throw new SmppInvalidArgumentException(String.format(msg, destinationFlag));
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder buffer = new StringBuilder();
+        buffer.append("dest_flag=0x").append(HexUtil.toHexString(destinationFlag));
+        buffer.append(" address=");
+        buffer.append(StringUtil.toStringWithNullAsEmpty(address));
+        buffer.append(" distribution_list_name=");
+        buffer.append(StringUtil.toStringWithNullAsEmpty(distributionListName));
+        return buffer.toString();
+    }
+}

--- a/src/main/java/com/cloudhopper/smpp/type/SubmitMultiUnsuccessSme.java
+++ b/src/main/java/com/cloudhopper/smpp/type/SubmitMultiUnsuccessSme.java
@@ -1,0 +1,83 @@
+package com.cloudhopper.smpp.type;
+
+/*
+ * #%L
+ * ch-smpp
+ * %%
+ * Copyright (C) 2009 - 2014 Cloudhopper by Twitter
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.cloudhopper.commons.util.StringUtil;
+import com.cloudhopper.smpp.util.ChannelBufferUtil;
+import com.cloudhopper.smpp.util.PduUtil;
+import org.jboss.netty.buffer.ChannelBuffer;
+
+public class SubmitMultiUnsuccessSme {
+
+    private Address address;
+    private int errorStatusCode;
+
+    public SubmitMultiUnsuccessSme() {
+    }
+
+    public SubmitMultiUnsuccessSme(final Address address, final int errorStatusCode) {
+        this.address = address;
+        this.errorStatusCode = errorStatusCode;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress(final Address address) {
+        this.address = address;
+    }
+
+    public int getErrorStatusCode() {
+        return errorStatusCode;
+    }
+
+    public void setErrorStatusCode(final int errorStatusCode) {
+        this.errorStatusCode = errorStatusCode;
+    }
+
+    public void readBody(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
+        address = ChannelBufferUtil.readAddress(buffer);
+        errorStatusCode = buffer.readInt();
+    }
+
+    public int calculateByteSizeOfBody() {
+        return PduUtil.calculateByteSizeOfAddress(address) + 4; //errorStatusCode
+    }
+
+    public void writeBody(ChannelBuffer buffer) throws UnrecoverablePduException, RecoverablePduException {
+        ChannelBufferUtil.writeAddress(buffer, address);
+        buffer.writeInt(errorStatusCode);
+    }
+
+    public void appendBodyToString(StringBuilder buffer) {
+        buffer.append("(address [").append(StringUtil.toStringWithNullAsEmpty(address));
+        buffer.append("] error_status_code [").append(errorStatusCode).append("])");
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder buffer = new StringBuilder();
+        buffer.append("(address [").append(StringUtil.toStringWithNullAsEmpty(address));
+        buffer.append("] error_status_code [").append(errorStatusCode).append("])");
+        return buffer.toString();
+    }
+}

--- a/src/main/java/com/cloudhopper/smpp/util/PduUtil.java
+++ b/src/main/java/com/cloudhopper/smpp/util/PduUtil.java
@@ -22,6 +22,10 @@ package com.cloudhopper.smpp.util;
 
 import com.cloudhopper.smpp.SmppConstants;
 import com.cloudhopper.smpp.type.Address;
+import com.cloudhopper.smpp.type.SubmitMultiDestinationAddress;
+import com.cloudhopper.smpp.type.SubmitMultiUnsuccessSme;
+
+import java.util.List;
 
 /**
  *
@@ -54,6 +58,37 @@ public class PduUtil {
         } else {
             return value.calculateByteSize();
         }
+    }
+
+    /**
+     * Calculates the byte size of number_of_dests + dest_address(es) for submit_multi.
+     * If called with null or empty list parameter returns 0 (although note that SMPP spec
+     * requires at least 1 destination address).
+     *
+     * @param addressList submit_multi destination address list
+     * @return byte size
+     */
+    static public int calculateByteSizeOfSubmitMultiAddressList(List<SubmitMultiDestinationAddress> addressList) {
+        if (addressList == null || addressList.isEmpty()) {
+            return 0;
+        }
+
+        int size = 1; //number_of_dests
+        for (SubmitMultiDestinationAddress address : addressList) {
+            size += address.calculateByteSize();
+        }
+
+        return size;
+    }
+
+    static public int calculateByteSizeOfSubmitMultiUnsucessSmeList(List<SubmitMultiUnsuccessSme> list) {
+        int size = 1; //no_unsuccess
+        if (list != null) {
+            for (SubmitMultiUnsuccessSme unsuccessSme : list) {
+                size += unsuccessSme.calculateByteSizeOfBody();
+            }
+        }
+        return size;
     }
 
     static public boolean isRequestCommandId(int commandId) {

--- a/src/test/java/com/cloudhopper/smpp/demo/SubmitMultiMain.java
+++ b/src/test/java/com/cloudhopper/smpp/demo/SubmitMultiMain.java
@@ -1,0 +1,154 @@
+package com.cloudhopper.smpp.demo;
+
+/*
+ * #%L
+ * ch-smpp
+ * %%
+ * Copyright (C) 2009 - 2012 Cloudhopper by Twitter
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.cloudhopper.commons.util.windowing.WindowFuture;
+import com.cloudhopper.smpp.SmppBindType;
+import com.cloudhopper.smpp.SmppSession;
+import com.cloudhopper.smpp.SmppSessionConfiguration;
+import com.cloudhopper.smpp.impl.DefaultSmppClient;
+import com.cloudhopper.smpp.impl.DefaultSmppSessionHandler;
+import com.cloudhopper.smpp.pdu.PduRequest;
+import com.cloudhopper.smpp.pdu.PduResponse;
+import com.cloudhopper.smpp.pdu.SubmitMulti;
+import com.cloudhopper.smpp.pdu.SubmitMultiResp;
+import com.cloudhopper.smpp.test.SmppTestDataProvider;
+import com.cloudhopper.smpp.type.Address;
+import com.cloudhopper.smpp.type.SubmitMultiDestinationAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @author innar.made@ishisystems.com
+ */
+public class SubmitMultiMain {
+
+    private static final Logger logger = LoggerFactory.getLogger(SubmitMultiMain.class);
+
+    private static ThreadPoolExecutor executor;
+    private static ScheduledThreadPoolExecutor monitorExecutor;
+    private static DefaultSmppClient clientBootstrap;
+    private static SmppSession session;
+
+    public static void main(String[] args) throws Exception {
+        createClient();
+        promptSendSubmitMulti();
+        sendRequest(getSubmitMulti());
+        promptDisconnect();
+        disconnect();
+    }
+
+    private static void createClient() throws Exception {
+        executor = (ThreadPoolExecutor) Executors.newCachedThreadPool();
+
+        monitorExecutor = (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(1, new ThreadFactory() {
+            private AtomicInteger sequence = new AtomicInteger(0);
+
+            @Override
+            public Thread newThread(Runnable runnable) {
+                Thread t = new Thread(runnable);
+                t.setName("SmppClientSessionWindowMonitorPool-" + sequence.getAndIncrement());
+                return t;
+            }
+        });
+
+        clientBootstrap = new DefaultSmppClient(executor, 1, monitorExecutor);
+        DefaultSmppSessionHandler sessionHandler = new ClientSmppSessionHandler();
+
+        SmppSessionConfiguration configuration = new SmppSessionConfiguration();
+        configuration.setWindowSize(1);
+        configuration.setName("Tester.Session.0");
+        configuration.setType(SmppBindType.TRANSCEIVER);
+        configuration.setHost("127.0.0.1");
+        configuration.setPort(2776);
+        configuration.setConnectTimeout(10000);
+        configuration.setSystemId("smppclient1");
+        configuration.setPassword("password");
+        configuration.getLoggingOptions().setLogBytes(true);
+        configuration.setRequestExpiryTimeout(30000);
+        configuration.setWindowMonitorInterval(15000);
+        configuration.setCountersEnabled(true);
+
+        session = clientBootstrap.bind(configuration, sessionHandler);
+    }
+
+    private static SubmitMulti getSubmitMulti() throws Exception {
+        SubmitMulti submitMulti = SmppTestDataProvider.getDefaultSubmitMulti();
+        List<SubmitMultiDestinationAddress> addressList = new ArrayList<SubmitMultiDestinationAddress>();
+        addressList.add(new SubmitMultiDestinationAddress(new Address((byte) 4, (byte) 5, "987654321")));
+        addressList.add(new SubmitMultiDestinationAddress("12345678901"));
+        addressList.add(new SubmitMultiDestinationAddress(new Address((byte) 7, (byte) 8, "123454321")));
+        submitMulti.setSubmitMultiDestinationAddressList(addressList);
+        return submitMulti;
+    }
+
+    private static void sendRequest(SubmitMulti submitMulti) throws Exception {
+        WindowFuture<Integer, PduRequest, PduResponse> future = session.sendRequestPdu(submitMulti, 10000, true);
+        if (!future.await()) {
+            logger.error("Failed to receive submit_multi_resp within specified time");
+        } else if (future.isSuccess()) {
+            SubmitMultiResp submitMultiResp = (SubmitMultiResp) future.getResponse();
+            logger.info("submit_multi_resp: commandStatus [" + submitMultiResp.getCommandStatus() + "=" + submitMultiResp.getResultMessage() + "]");
+        } else {
+            logger.error("Failed to properly receive submit_multi_resp: " + future.getCause());
+        }
+    }
+
+    private static void promptSendSubmitMulti() throws IOException {
+        System.out.println("Press any key to send submit_multi");
+        System.in.read();
+    }
+
+    private static void promptDisconnect() throws IOException {
+        System.out.println("Press any key to unbind and close sessions");
+        System.in.read();
+    }
+
+    private static void disconnect() {
+        session.unbind(5000);
+        clientBootstrap.destroy();
+        executor.shutdownNow();
+        monitorExecutor.shutdownNow();
+    }
+
+    public static class ClientSmppSessionHandler extends DefaultSmppSessionHandler {
+
+        public ClientSmppSessionHandler() {
+            super(logger);
+        }
+
+        @Override
+        public PduResponse firePduRequestReceived(PduRequest pduRequest) {
+            return pduRequest.createResponse();
+        }
+
+    }
+
+}

--- a/src/test/java/com/cloudhopper/smpp/test/SmppAssert.java
+++ b/src/test/java/com/cloudhopper/smpp/test/SmppAssert.java
@@ -1,0 +1,139 @@
+package com.cloudhopper.smpp.test;
+
+/*
+ * #%L
+ * ch-smpp
+ * %%
+ * Copyright (C) 2009 - 2014 Cloudhopper by Twitter
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.cloudhopper.smpp.pdu.SubmitMulti;
+import com.cloudhopper.smpp.pdu.SubmitMultiResp;
+import com.cloudhopper.smpp.type.Address;
+import com.cloudhopper.smpp.type.SubmitMultiDestinationAddress;
+import com.cloudhopper.smpp.type.SubmitMultiUnsuccessSme;
+import org.junit.Assert;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author innar.made@ishisystems.com
+ */
+public class SmppAssert {
+
+    private SmppAssert() {}
+
+    public static void assertSubmitMulti(SubmitMulti expected, SubmitMulti actual) {
+        assertEquals("command_length", expected.getCommandLength(), actual.getCommandLength());
+        assertEquals("command_id", expected.getCommandId(), actual.getCommandId());
+        assertEquals("command_status", expected.getCommandStatus(), actual.getCommandStatus());
+        assertEquals("sequence_number", expected.getSequenceNumber(), actual.getSequenceNumber());
+        assertEquals("service_type", expected.getServiceType(), actual.getServiceType());
+        assertAddress(expected.getSourceAddress(), actual.getSourceAddress());
+        assertSubmitMultiDestinationAddressList(
+                expected.getSubmitMultiDestinationAddressList(), actual.getSubmitMultiDestinationAddressList());
+        assertEquals("esm_class", expected.getEsmClass(), actual.getEsmClass());
+        assertEquals("protocol_id", expected.getProtocolId(), actual.getProtocolId());
+        assertEquals("priority", expected.getPriority(), actual.getPriority());
+        assertEquals("schedule", expected.getScheduleDeliveryTime(), actual.getScheduleDeliveryTime());
+        assertEquals("validity", expected.getValidityPeriod(), actual.getValidityPeriod());
+        assertEquals("registered_delivery", expected.getRegisteredDelivery(), actual.getRegisteredDelivery());
+        assertEquals("replace_if_present", expected.getReplaceIfPresent(), actual.getReplaceIfPresent());
+        assertEquals("data_coding", expected.getDataCoding(), actual.getDataCoding());
+        assertEquals("default_msg_id", expected.getDefaultMsgId(), actual.getDefaultMsgId());
+        Assert.assertArrayEquals("short_msg", expected.getShortMessage(), actual.getShortMessage());
+    }
+
+    public static void assertSubmitMultiResp(SubmitMultiResp expected, SubmitMultiResp actual) {
+        assertNullity(expected, actual);
+        if (expected == null) {
+            return;
+        }
+        assertEquals("command_length", expected.getCommandLength(), actual.getCommandLength());
+        assertEquals("command_id", expected.getCommandId(), actual.getCommandId());
+        assertEquals("command_status", expected.getCommandStatus(), actual.getCommandStatus());
+        assertEquals("sequence_number", expected.getSequenceNumber(), actual.getSequenceNumber());
+        assertEquals("message_id", expected.getMessageId(), actual.getMessageId());
+        final int numberOfUnsuccessSmes = expected.getNumberOfUnsuccessSmes();
+        assertEquals("no_unsuccess", numberOfUnsuccessSmes, actual.getNumberOfUnsuccessSmes());
+        if (numberOfUnsuccessSmes > 0) {
+            for (int i = 0; i < numberOfUnsuccessSmes; i++) {
+                assertSubmitMultiUnsuccessSme(expected.getUnsuccessSmes().get(i), actual.getUnsuccessSmes().get(i));
+            }
+        } else {
+            assertNullity(expected.getUnsuccessSmes(), actual.getUnsuccessSmes());
+        }
+    }
+
+    public static void assertAddress(Address expected, Address actual) {
+        assertNullity(expected, actual);
+        if (expected == null) {
+            return;
+        }
+        assertEquals("ton", expected.getTon(), actual.getTon());
+        assertEquals("npi", expected.getNpi(), actual.getNpi());
+        assertEquals("address", expected.getAddress(), actual.getAddress());
+    }
+
+    public static void assertSubmitMultiDestinationAddressList(List<SubmitMultiDestinationAddress> expected,
+                                                               List<SubmitMultiDestinationAddress> actual) {
+        assertNullity(expected, actual);
+        if (expected == null) {
+            return;
+        }
+        assertEquals("number_of_dests", expected.size(), actual.size());
+        for (int i = 0; i < expected.size(); i++) {
+            SubmitMultiDestinationAddress e = expected.get(i);
+            SubmitMultiDestinationAddress a = actual.get(i);
+            assertSubmitMultiDestinationAddress(e, a);
+        }
+    }
+
+    public static void assertSubmitMultiDestinationAddress(SubmitMultiDestinationAddress expected,
+                                                           SubmitMultiDestinationAddress actual) {
+        assertNullity(expected, actual);
+        if (expected == null) {
+            return;
+        }
+        assertEquals("dest_flag", expected.getDestinationFlag(), actual.getDestinationFlag());
+        if (expected.isAddress()) {
+            assertAddress(expected.getAddress(), actual.getAddress());
+        } else if (expected.isDistributionListName()) {
+            assertEquals(expected.getDistributionListName(), actual.getDistributionListName());
+        } else {
+            Assert.fail("Invalid dest_flag value " + expected.getDestinationFlag());
+        }
+    }
+
+    public static void assertSubmitMultiUnsuccessSme(SubmitMultiUnsuccessSme expected, SubmitMultiUnsuccessSme actual) {
+        assertNullity(expected, actual);
+        if (expected == null) {
+            return;
+        }
+        assertAddress(expected.getAddress(), actual.getAddress());
+        assertEquals("error_status_code", expected.getErrorStatusCode(), actual.getErrorStatusCode());
+    }
+
+    private static void assertNullity(Object expected, Object actual) {
+        if (expected != null) {
+            assertNotNull("Actual object must not be null", actual);
+        } else {
+            assertNull("Actual object must be null", actual);
+        }
+    }
+}

--- a/src/test/java/com/cloudhopper/smpp/test/SmppTestDataProvider.java
+++ b/src/test/java/com/cloudhopper/smpp/test/SmppTestDataProvider.java
@@ -1,0 +1,71 @@
+package com.cloudhopper.smpp.test;
+
+/*
+ * #%L
+ * ch-smpp
+ * %%
+ * Copyright (C) 2009 - 2014 Cloudhopper by Twitter
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.cloudhopper.commons.gsm.DataCoding;
+import com.cloudhopper.commons.util.HexUtil;
+import com.cloudhopper.smpp.SmppConstants;
+import com.cloudhopper.smpp.pdu.SubmitMulti;
+import com.cloudhopper.smpp.pdu.SubmitMultiResp;
+import com.cloudhopper.smpp.type.Address;
+
+/**
+ * @author innar.made@ishisystems.com
+ */
+public class SmppTestDataProvider {
+
+    private SmppTestDataProvider() {}
+
+    public static SubmitMulti getDefaultSubmitMulti() throws Exception {
+        SubmitMulti pdu = new SubmitMulti();
+        pdu.setSequenceNumber(20456);
+        pdu.setServiceType("abc123");
+        pdu.setSourceAddress(new Address((byte) 4, (byte) 5, "123456789"));
+        pdu.setEsmClass((byte) 1);
+        pdu.setProtocolId((byte) 3);
+        pdu.setPriority((byte) 2);
+        pdu.setScheduleDeliveryTime("140101000000000+");
+        pdu.setValidityPeriod("140231235959948-");
+        pdu.setRegisteredDelivery((byte) 1);
+        pdu.setReplaceIfPresent((byte) 0);
+        pdu.setDataCoding(DataCoding.CHAR_ENC_LATIN1);
+        pdu.setDefaultMsgId((byte) 55);
+        pdu.setShortMessage("Hello World".getBytes("ISO-8859-1"));
+        return pdu;
+    }
+
+    public static String getDefaultSubmitMultiPduHex(String submitMultiDestinationHex) {
+        int length = 88 + (submitMultiDestinationHex.length() / 2);
+        return String.format("%s000000210000000000004FE861626331323300" +
+                        "040531323334353637383900%s0103023134303130313030303030303030302B00" +
+                        "3134303233313233353935393934382D00010003370B48656C6C6F20576F726C64",
+                HexUtil.toHexString(length), submitMultiDestinationHex);
+    }
+
+    public static SubmitMultiResp getDefaultSubmitMultiResp() {
+        SubmitMultiResp pdu = new SubmitMultiResp();
+        pdu.setCommandStatus(SmppConstants.STATUS_OK);
+        pdu.setSequenceNumber(20456);
+        pdu.setMessageId("a1-b2-c3-d4-e5-f6-g7");
+        pdu.setUnsuccessSmes(null);
+        return pdu;
+    }
+}


### PR DESCRIPTION
Submit_multi operation implementation (SMPP 3.4 section 4.5) along with test cases and demo client. Also verified that wireshark is able to parse submit_multi PDUs correctly.
