### PR TITLE
Override equals and hashCode in Tlv class.

### DIFF
--- a/src/main/java/com/cloudhopper/smpp/tlv/Tlv.java
+++ b/src/main/java/com/cloudhopper/smpp/tlv/Tlv.java
@@ -23,6 +23,7 @@ package com.cloudhopper.smpp.tlv;
 import com.cloudhopper.commons.util.ByteArrayUtil;
 import com.cloudhopper.commons.util.HexUtil;
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
 
 /**
  * Tag-Length-Value optional parameter in SMPP.
@@ -255,5 +256,36 @@ public class Tlv {
         } catch (IllegalArgumentException e) {
             throw new TlvConvertException("long", e.getMessage());
         }
+    }
+
+    /**
+     * Checks if another Tlv object is equal to this Tlv object. Two tlv objects
+     * are considered equal if they have the same tag and the same value.
+     * 
+     * @param t
+     * @return true if this and t have the same tag and value, false otherwise.
+     */
+    @Override
+    public boolean equals(Object t){
+        if (t == null){
+            return false;
+        } else if(this == t){
+            return true;
+        }
+        Tlv other = (Tlv) t;
+        return other.tag == this.tag && Arrays.equals(other.value, this.value);
+    }
+
+    /**
+     * Computes a valid hash code for this Tlv object.
+     * 
+     * @return int hash code for this object.
+     */
+    @Override
+    public int hashCode(){
+        int hash = 42;
+        hash = 31 * hash + ((int) this.tag);
+        hash = 31 * hash + Arrays.hashCode(this.value);
+        return hash;
     }
 }

--- a/src/test/java/com/cloudhopper/smpp/tlv/TlvTest.java
+++ b/src/test/java/com/cloudhopper/smpp/tlv/TlvTest.java
@@ -288,7 +288,7 @@ public class TlvTest {
     public void testEquals() throws Exception{
         Tlv tlv0 = new Tlv((short) 0x88, "equals".getBytes());
         // Trivial case
-        Assert.assertEquals(tlv0.equals(tlv0));
+        Assert.assertTrue(tlv0.equals(tlv0));
         Tlv tlv0Mirror = new Tlv((short) 0x88, "equals".getBytes());
         // Reflexivity
         Assert.assertEquals(tlv0, tlv0);

--- a/src/test/java/com/cloudhopper/smpp/tlv/TlvTest.java
+++ b/src/test/java/com/cloudhopper/smpp/tlv/TlvTest.java
@@ -283,4 +283,50 @@ public class TlvTest {
             // correct behavior
         }
     }
+
+    @Test
+    public void testEquals() throws Exception{
+        Tlv tlv0 = new Tlv((short) 0x88, "equals".getBytes());
+        // Trivial case
+        Assert.assertEquals(tlv0.equals(tlv0));
+        Tlv tlv0Mirror = new Tlv((short) 0x88, "equals".getBytes());
+        // Reflexivity
+        Assert.assertEquals(tlv0, tlv0);
+        // Symmetry
+        Assert.assertTrue(tlv0.equals(tlv0Mirror));
+        Assert.assertTrue(tlv0Mirror.equals(tlv0));
+        
+        // Transitivity
+        Tlv tlv0Transitive = new Tlv((short) 0x88, "equals".getBytes());
+        Assert.assertTrue(tlv0.equals(tlv0Transitive));
+        Assert.assertTrue(tlv0Mirror.equals(tlv0Transitive));
+
+        // Non nullity
+        Assert.assertFalse(tlv0.equals(null));
+
+        // Some more non-equality tests
+        Tlv differentTag = new Tlv((short) 0x77, "equals".getBytes());
+        Tlv differentVal = new Tlv((short) 0x88, "nonequals".getBytes());
+        Tlv differentAll = new Tlv((short) 0x77, "nonequals".getBytes());
+
+        Assert.assertNotEquals(tlv0, differentTag);
+        Assert.assertNotEquals(tlv0, differentVal);
+        Assert.assertNotEquals(tlv0, differentAll);
+    }
+
+    @Test
+    public void testHashCode() throws Exception{
+        Tlv tlv0 = new Tlv((short) 0x88, "equals".getBytes());
+        Tlv tlv0Mirror = new Tlv((short) 0x88, "equals".getBytes());
+        Assert.assertEquals(tlv0.hashCode(), tlv0Mirror.hashCode());
+
+        Tlv differentTag = new Tlv((short) 0x77, "equals".getBytes());
+        Tlv differentVal = new Tlv((short) 0x88, "nonequals".getBytes());
+        Tlv differentAll = new Tlv((short) 0x77, "nonequals".getBytes());
+
+        Assert.assertNotEquals(tlv0.hashCode(), differentTag.hashCode());
+        Assert.assertNotEquals(tlv0.hashCode(), differentVal.hashCode());
+        Assert.assertNotEquals(tlv0.hashCode(), differentAll.hashCode());
+    }
+
 }


### PR DESCRIPTION
My project will benefit if Tlv has `equals` and `hashCode` overriden so I'm hoping this gets to a Maven release. :)

For reference, the `equals` and `hashCode` methods I've implemented derives from Effective Java 2e by Joshua Bloch (Items 8 and 9).
