### PR TITLE
Split DefaultSmppSession into DefaultSmppClientSession and DefaultSmppServerSession

### DIFF
--- a/src/main/java/com/cloudhopper/smpp/SmppClient.java
+++ b/src/main/java/com/cloudhopper/smpp/SmppClient.java
@@ -53,7 +53,7 @@ public interface SmppClient {
      * @throws InterruptedException Thrown if the calling thread is interrupted
      * while we are attempting the bind.
      */
-    public SmppSession bind(SmppSessionConfiguration config, SmppSessionHandler sessionHandler) throws SmppTimeoutException, SmppChannelException, SmppBindException, UnrecoverablePduException, InterruptedException;
+    public SmppClientSession bind(SmppSessionConfiguration config, SmppSessionHandler sessionHandler) throws SmppTimeoutException, SmppChannelException, SmppBindException, UnrecoverablePduException, InterruptedException;
 
     /**
      * Destroy a client by ensuring that all session sockets are closed and all

--- a/src/main/java/com/cloudhopper/smpp/SmppClientSession.java
+++ b/src/main/java/com/cloudhopper/smpp/SmppClientSession.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015 Cloudhopper by Twitter.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudhopper.smpp;
+
+/*
+ * #%L
+ * ch-smpp
+ * %%
+ * Copyright (C) 2009 - 2015 Cloudhopper by Twitter
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.cloudhopper.smpp.pdu.BaseBind;
+import com.cloudhopper.smpp.pdu.BaseBindResp;
+import com.cloudhopper.smpp.pdu.SubmitSm;
+import com.cloudhopper.smpp.pdu.SubmitSmResp;
+import com.cloudhopper.smpp.type.RecoverablePduException;
+import com.cloudhopper.smpp.type.SmppBindException;
+import com.cloudhopper.smpp.type.SmppChannelException;
+import com.cloudhopper.smpp.type.SmppTimeoutException;
+import com.cloudhopper.smpp.type.UnrecoverablePduException;
+
+/**
+ *
+ * @author pgoergler
+ */
+public interface SmppClientSession extends SmppSession {
+
+    public BaseBindResp bind(BaseBind request, long timeoutInMillis) throws RecoverablePduException, UnrecoverablePduException, SmppBindException, SmppTimeoutException, SmppChannelException, InterruptedException;
+    
+    /**
+     * Synchronously sends a "submit" request to the remote endpoint and
+     * waits for up to a specified number of milliseconds for a response. The
+     * timeout value includes both waiting for a "window" slot, the time it
+     * takes to transmit the actual bytes on the socket, and for the remote
+     * endpoint to send a response back.
+     * @param request The request to send to the remote endpoint
+     * @param timeoutMillis The number of milliseconds to wait until a valid
+     *      response is received.
+     * @return A valid response to the request
+     * @throws RecoverablePduException Thrown when a recoverable PDU error occurs.
+     *      A recoverable PDU error includes the partially decoded PDU in order
+     *      to generate a negative acknowledgement (NACK) response.
+     * @throws UnrecoverablePduException Thrown when an unrecoverable PDU error
+     *      occurs. This indicates a seriours error occurred and usually indicates
+     *      the session should be immediately terminated.
+     * @throws SmppTimeoutException A timeout occurred while waiting for a response
+     *      from the remote endpoint.  A timeout can either occur with an unresponse
+     *      remote endpoint or the bytes were not written in time.
+     * @throws SmppChannelException Thrown when the underlying socket/channel was
+     *      unable to write the request.
+     * @throws InterruptedException The calling thread was interrupted while waiting
+     *      to acquire a lock or write/read the bytes from the socket/channel.
+     */
+    public SubmitSmResp submit(SubmitSm request, long timeoutMillis) throws RecoverablePduException, UnrecoverablePduException, SmppTimeoutException, SmppChannelException, InterruptedException;
+
+}

--- a/src/main/java/com/cloudhopper/smpp/impl/DefaultSmppClientSession.java
+++ b/src/main/java/com/cloudhopper/smpp/impl/DefaultSmppClientSession.java
@@ -1,0 +1,148 @@
+package com.cloudhopper.smpp.impl;
+
+import com.cloudhopper.smpp.SmppClientSession;
+import com.cloudhopper.smpp.SmppConstants;
+import com.cloudhopper.smpp.SmppSessionConfiguration;
+import com.cloudhopper.smpp.SmppSessionHandler;
+import com.cloudhopper.smpp.pdu.BaseBind;
+import com.cloudhopper.smpp.pdu.BaseBindResp;
+import com.cloudhopper.smpp.pdu.PduResponse;
+import com.cloudhopper.smpp.pdu.SubmitSm;
+import com.cloudhopper.smpp.pdu.SubmitSmResp;
+import com.cloudhopper.smpp.tlv.Tlv;
+import com.cloudhopper.smpp.tlv.TlvConvertException;
+import com.cloudhopper.smpp.type.RecoverablePduException;
+import com.cloudhopper.smpp.type.SmppBindException;
+import com.cloudhopper.smpp.type.SmppChannelException;
+import com.cloudhopper.smpp.type.SmppTimeoutException;
+import com.cloudhopper.smpp.type.UnrecoverablePduException;
+import com.cloudhopper.smpp.util.SmppSessionUtil;
+import java.util.concurrent.ScheduledExecutorService;
+import org.jboss.netty.channel.Channel;
+
+/*
+ * #%L
+ * ch-smpp
+ * %%
+ * Copyright (C) 2009 - 2015 Cloudhopper by Twitter
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/**
+ * Default implementation of and SMSC SMPP session.
+ *
+ */
+public class DefaultSmppClientSession extends AbstractSmppSession implements SmppClientSession {
+
+    /**
+     * Creates an SmppSession for a client-based session. It is <b>NOT</b>
+     * recommended that this constructor is called directly. The recommended way
+     * to construct a session is either via a DefaultSmppClient or
+     * DefaultSmppServer. This constructor will cause monitoring to be disabled.
+     *
+     * @param localType The type of local endpoint (ESME vs. SMSC)
+     * @param configuration The session configuration
+     * @param channel The channel associated with this session. The channel
+     * needs to already be opened.
+     * @param sessionHandler The handler for session events
+     */
+    public DefaultSmppClientSession(Type localType, SmppSessionConfiguration configuration, Channel channel, SmppSessionHandler sessionHandler) {
+        super(localType, configuration, channel, sessionHandler, null);
+    }
+
+    /**
+     * Creates an SmppSession for a client-based session. It is <b>NOT</b>
+     * recommended that this constructor is called directly. The recommended way
+     * to construct a session is either via a DefaultSmppClient or
+     * DefaultSmppServer.
+     *
+     * @param localType The type of local endpoint (ESME vs. SMSC)
+     * @param configuration The session configuration
+     * @param channel The channel associated with this session. The channel
+     * needs to already be opened.
+     * @param sessionHandler The handler for session events
+     * @param monitorExecutor The executor that window monitoring and
+     * potentially statistics will be periodically executed under. If null,
+     * monitoring will be disabled.
+     */
+    public DefaultSmppClientSession(Type localType, SmppSessionConfiguration configuration, Channel channel, SmppSessionHandler sessionHandler, ScheduledExecutorService monitorExecutor) {
+        super(localType, configuration, channel, sessionHandler, monitorExecutor);
+    }
+
+    @Override
+    public BaseBindResp bind(BaseBind request, long timeoutInMillis) throws RecoverablePduException, UnrecoverablePduException, SmppBindException, SmppTimeoutException, SmppChannelException, InterruptedException {
+        assertValidRequest(request);
+        boolean bound = false;
+        try {
+            this.state.set(STATE_BINDING);
+
+            PduResponse response = sendRequestAndGetResponse(request, timeoutInMillis);
+            SmppSessionUtil.assertExpectedResponse(request, response);
+            BaseBindResp bindResponse = (BaseBindResp) response;
+
+            // check if the bind succeeded
+            if (bindResponse == null || bindResponse.getCommandStatus() != SmppConstants.STATUS_OK) {
+                // bind failed for a specific reason
+                throw new SmppBindException(bindResponse);
+            }
+
+            // if we make it all the way here, we're good and bound
+            bound = true;
+
+            //
+            // negotiate version in use based on response back from server
+            //
+            Tlv scInterfaceVersion = bindResponse.getOptionalParameter(SmppConstants.TAG_SC_INTERFACE_VERSION);
+
+            if (scInterfaceVersion == null) {
+                // this means version 3.3 is in use
+                this.interfaceVersion = SmppConstants.VERSION_3_3;
+            } else {
+                try {
+                    byte tempInterfaceVersion = scInterfaceVersion.getValueAsByte();
+                    if (tempInterfaceVersion >= SmppConstants.VERSION_3_4) {
+                        this.interfaceVersion = SmppConstants.VERSION_3_4;
+                    } else {
+                        this.interfaceVersion = SmppConstants.VERSION_3_3;
+                    }
+                } catch (TlvConvertException e) {
+                    logger.warn("Unable to convert sc_interface_version to a byte value: {}", e.getMessage());
+                    this.interfaceVersion = SmppConstants.VERSION_3_3;
+                }
+            }
+
+            return bindResponse;
+        } finally {
+            if (bound) {
+                // this session is now successfully bound & ready for processing
+                setBound();
+            } else {
+                // the bind failed, we need to clean up resources
+                try {
+                    this.close();
+                } catch (Exception e) {
+                }
+            }
+        }
+    }
+
+    @Override
+    public SubmitSmResp submit(SubmitSm request, long timeoutInMillis) throws RecoverablePduException, UnrecoverablePduException, SmppTimeoutException, SmppChannelException, InterruptedException {
+        assertValidRequest(request);
+        PduResponse response = sendRequestAndGetResponse(request, timeoutInMillis);
+        SmppSessionUtil.assertExpectedResponse(request, response);
+        return (SubmitSmResp) response;
+    }
+
+}

--- a/src/main/java/com/cloudhopper/smpp/impl/DefaultSmppServerSession.java
+++ b/src/main/java/com/cloudhopper/smpp/impl/DefaultSmppServerSession.java
@@ -1,0 +1,91 @@
+package com.cloudhopper.smpp.impl;
+
+/*
+ * #%L
+ * ch-smpp
+ * %%
+ * Copyright (C) 2009 - 2015 Cloudhopper by Twitter
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+import com.cloudhopper.smpp.SmppServerSession;
+import com.cloudhopper.smpp.SmppSessionConfiguration;
+import com.cloudhopper.smpp.SmppSessionHandler;
+import com.cloudhopper.smpp.pdu.BaseBindResp;
+import java.util.concurrent.ScheduledExecutorService;
+import org.jboss.netty.channel.Channel;
+
+/**
+ * Default implementation of an ESME SMPP session.
+ *
+ */
+public class DefaultSmppServerSession extends AbstractSmppSession implements SmppServerSession {
+
+    protected DefaultSmppServer server;
+    // the session id assigned by the server to this particular instance
+    protected Long serverSessionId;
+    // pre-prepared BindResponse to send back once we're flagged as ready
+    protected BaseBindResp preparedBindResponse;
+
+    /**
+     * Creates an SmppSession for a server-based session.
+     *
+     * @param localType The type of local endpoint (ESME vs. SMSC)
+     * @param configuration The session configuration
+     * @param channel The channel associated with this session. The channel
+     * needs to already be opened.
+     * @param server
+     * @param serverSessionId
+     * @param preparedBindResponse
+     * @param interfaceVersion
+     * @param monitorExecutor The executor that window monitoring and
+     * potentially statistics will be periodically executed under. If null,
+     * monitoring will be disabled.
+     */
+    public DefaultSmppServerSession(Type localType, SmppSessionConfiguration configuration, Channel channel, DefaultSmppServer server, Long serverSessionId, BaseBindResp preparedBindResponse, byte interfaceVersion, ScheduledExecutorService monitorExecutor) {
+        super(localType, configuration, channel, (SmppSessionHandler) null, monitorExecutor);
+        // default state for a server session is that it's binding
+        this.state.set(STATE_BINDING);
+        this.server = server;
+        this.serverSessionId = serverSessionId;
+        this.preparedBindResponse = preparedBindResponse;
+        this.interfaceVersion = interfaceVersion;
+    }
+
+    @Override
+    public void serverReady(SmppSessionHandler sessionHandler) {
+        // properly setup the session handler (to handle notifications)
+        this.sessionHandler = sessionHandler;
+        // send the prepared bind response
+        try {
+            this.sendResponsePdu(this.preparedBindResponse);
+        } catch (Exception e) {
+            logger.error("{}", e);
+        }
+        // flag the channel is ready to read
+        this.channel.setReadable(true).awaitUninterruptibly();
+        this.setBound();
+    }
+
+    @Override
+    public void fireChannelClosed() {
+        // if this is a server session, we need to notify the server first
+        // NOTE: its important this happens first
+        if (this.server != null) {
+            this.server.destroySession(serverSessionId, this);
+        }
+        super.fireChannelClosed();
+    }
+
+}

--- a/src/test/java/com/cloudhopper/smpp/demo/ClientMain.java
+++ b/src/test/java/com/cloudhopper/smpp/demo/ClientMain.java
@@ -24,7 +24,7 @@ import com.cloudhopper.commons.charset.CharsetUtil;
 import com.cloudhopper.commons.util.windowing.WindowFuture;
 import com.cloudhopper.smpp.SmppSessionConfiguration;
 import com.cloudhopper.smpp.SmppBindType;
-import com.cloudhopper.smpp.SmppSession;
+import com.cloudhopper.smpp.SmppClientSession;
 import com.cloudhopper.smpp.impl.DefaultSmppClient;
 import com.cloudhopper.smpp.impl.DefaultSmppSessionHandler;
 import com.cloudhopper.smpp.type.Address;
@@ -98,7 +98,7 @@ public class ClientMain {
         config0.setHost("127.0.0.1");
         config0.setPort(2776);
         config0.setConnectTimeout(10000);
-        config0.setSystemId("1234567890");
+        config0.setSystemId("client");
         config0.setPassword("password");
         config0.getLoggingOptions().setLogBytes(true);
         // to enable monitoring (request expiration)
@@ -109,7 +109,7 @@ public class ClientMain {
         //
         // create session, enquire link, submit an sms, close session
         //
-        SmppSession session0 = null;
+        SmppClientSession session0 = null;
 
         try {
             // create session a session by having the bootstrap connect a

--- a/src/test/java/com/cloudhopper/smpp/demo/QueryCancelMain.java
+++ b/src/test/java/com/cloudhopper/smpp/demo/QueryCancelMain.java
@@ -24,7 +24,7 @@ import com.cloudhopper.commons.charset.CharsetUtil;
 import com.cloudhopper.commons.util.windowing.WindowFuture;
 import com.cloudhopper.smpp.SmppSessionConfiguration;
 import com.cloudhopper.smpp.SmppBindType;
-import com.cloudhopper.smpp.SmppSession;
+import com.cloudhopper.smpp.SmppClientSession;
 import com.cloudhopper.smpp.impl.DefaultSmppClient;
 import com.cloudhopper.smpp.impl.DefaultSmppSessionHandler;
 import com.cloudhopper.smpp.type.Address;
@@ -114,7 +114,7 @@ public class QueryCancelMain {
         //
         // create session, enquire link, submit an sms, close session
         //
-        SmppSession session0 = null;
+        SmppClientSession session0 = null;
 
         try {
             // create session a session by having the bootstrap connect a

--- a/src/test/java/com/cloudhopper/smpp/demo/SslClientMain.java
+++ b/src/test/java/com/cloudhopper/smpp/demo/SslClientMain.java
@@ -24,7 +24,7 @@ import com.cloudhopper.commons.charset.CharsetUtil;
 import com.cloudhopper.commons.util.windowing.WindowFuture;
 import com.cloudhopper.smpp.SmppSessionConfiguration;
 import com.cloudhopper.smpp.SmppBindType;
-import com.cloudhopper.smpp.SmppSession;
+import com.cloudhopper.smpp.SmppClientSession;
 import com.cloudhopper.smpp.impl.DefaultSmppClient;
 import com.cloudhopper.smpp.impl.DefaultSmppSessionHandler;
 import com.cloudhopper.smpp.type.Address;
@@ -34,7 +34,6 @@ import com.cloudhopper.smpp.pdu.PduRequest;
 import com.cloudhopper.smpp.pdu.PduResponse;
 import com.cloudhopper.smpp.pdu.SubmitSm;
 import com.cloudhopper.smpp.pdu.SubmitSmResp;
-import com.cloudhopper.smpp.ssl.SslConfiguration;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
@@ -112,7 +111,7 @@ public class SslClientMain {
         //
         // create session, enquire link, submit an sms, close session
         //
-        SmppSession session0 = null;
+        SmppClientSession session0 = null;
 
         try {
             // create session a session by having the bootstrap connect a

--- a/src/test/java/com/cloudhopper/smpp/demo/persist/Client.java
+++ b/src/test/java/com/cloudhopper/smpp/demo/persist/Client.java
@@ -20,26 +20,26 @@ package com.cloudhopper.smpp.demo.persist;
  * #L%
  */
 
-import com.cloudhopper.smpp.SmppSession;
+import com.cloudhopper.smpp.SmppClientSession;
 import com.cloudhopper.smpp.SmppSessionConfiguration;
 
 public abstract class Client {
 
-	protected volatile SmppSession smppSession;
+	protected volatile SmppClientSession smppSession;
 
 	public SmppSessionConfiguration getConfiguration() {
 		return smppSession.getConfiguration();
 	}
 
 	public boolean isConnected() {
-		SmppSession session = smppSession;
+		SmppClientSession session = smppSession;
 		if (session != null) {
 			return session.isBound();
 		}
 		return false;
 	}
 
-	public SmppSession getSession() {
+	public SmppClientSession getSession() {
 		return smppSession;
 	}
 }

--- a/src/test/java/com/cloudhopper/smpp/demo/persist/Main.java
+++ b/src/test/java/com/cloudhopper/smpp/demo/persist/Main.java
@@ -65,7 +65,7 @@ public class Main {
 							long sent = alreadySent.incrementAndGet();
 							while (sent <= messagesToSend) {
 								final OutboundClient next = balancedList.getNext();
-								final SmppSession session = next.getSession();
+								final SmppClientSession session = next.getSession();
 								if (session != null && session.isBound()) {
 									String text160 = "\u20AC Lorem [ipsum] dolor sit amet, consectetur adipiscing elit. Proin feugiat, leo id commodo tincidunt, nibh diam ornare est, vitae accumsan risus lacus sed sem metus.";
 									byte[] textBytes = CharsetUtil.encode(text160, CharsetUtil.CHARSET_GSM);

--- a/src/test/java/com/cloudhopper/smpp/impl/DefaultSmppServerTest.java
+++ b/src/test/java/com/cloudhopper/smpp/impl/DefaultSmppServerTest.java
@@ -22,6 +22,7 @@ package com.cloudhopper.smpp.impl;
 
 // third party imports
 import com.cloudhopper.smpp.SmppBindType;
+import com.cloudhopper.smpp.SmppClientSession;
 import com.cloudhopper.smpp.SmppConstants;
 import com.cloudhopper.smpp.SmppServerConfiguration;
 import com.cloudhopper.smpp.SmppServerHandler;
@@ -214,7 +215,7 @@ public class DefaultSmppServerTest {
 
             // we will not use the proper method of binding since we need to 
             // access the bind response to verify it's correct
-            DefaultSmppSession session0 = client0.doOpen(sessionConfig0, new DefaultSmppSessionHandler());
+            SmppClientSession session0 = client0.doOpen(sessionConfig0, new DefaultSmppSessionHandler());
 
             // create a bind request based on this config
             BaseBind bindRequest = client0.createBindRequest(sessionConfig0);
@@ -271,7 +272,7 @@ public class DefaultSmppServerTest {
 
             // we will not use the proper method of binding since we need to
             // access the bind response to verify it's correct
-            DefaultSmppSession session0 = client0.doOpen(sessionConfig0, new DefaultSmppSessionHandler());
+            SmppClientSession session0 = client0.doOpen(sessionConfig0, new DefaultSmppSessionHandler());
 
             // create a bind request based on this config
             BaseBind bindRequest = client0.createBindRequest(sessionConfig0);
@@ -328,7 +329,7 @@ public class DefaultSmppServerTest {
 
             // we will not use the proper method of binding since we need to
             // access the bind response to verify it's correct
-            DefaultSmppSession session0 = client0.doOpen(sessionConfig0, new DefaultSmppSessionHandler());
+            SmppClientSession session0 = client0.doOpen(sessionConfig0, new DefaultSmppSessionHandler());
 
             // create a bind request based on this config
             BaseBind bindRequest = client0.createBindRequest(sessionConfig0);
@@ -389,7 +390,7 @@ public class DefaultSmppServerTest {
 
             // we will not use the proper method of binding since we need to
             // access the bind response to verify it's correct
-            DefaultSmppSession session0 = client0.doOpen(sessionConfig0, new DefaultSmppSessionHandler());
+            SmppClientSession session0 = client0.doOpen(sessionConfig0, new DefaultSmppSessionHandler());
 
             // create a bind request based on this config
             BaseBind bindRequest = client0.createBindRequest(sessionConfig0);
@@ -447,7 +448,7 @@ public class DefaultSmppServerTest {
             SmppSessionConfiguration sessionConfig0 = createDefaultConfiguration();
 
             // we will not use the proper method of binding since we need to
-            DefaultSmppSession session0 = client0.doOpen(sessionConfig0, new DefaultSmppSessionHandler());
+            SmppClientSession session0 = client0.doOpen(sessionConfig0, new DefaultSmppSessionHandler());
 
             // there is a bind timeout of 50 ms and we'll wait 100 ms
             Thread.sleep(100);
@@ -519,7 +520,7 @@ public class DefaultSmppServerTest {
                 SmppSessionConfiguration sessionConfig0 = createDefaultConfiguration();
                 sessionConfig0.setName("WorkerTest.Session." + i);
                 // don't use default method of binding, connect the socket first
-                DefaultSmppSession session0 = client0.doOpen(sessionConfig0, new DefaultSmppSessionHandler());
+                SmppClientSession session0 = client0.doOpen(sessionConfig0, new DefaultSmppSessionHandler());
                 // try to bind and execute a bind request and wait for a bind response
                 BaseBind bindRequest = client0.createBindRequest(sessionConfig0);
                 try {

--- a/src/test/java/com/cloudhopper/smpp/impl/DefaultSmppSessionTest.java
+++ b/src/test/java/com/cloudhopper/smpp/impl/DefaultSmppSessionTest.java
@@ -26,6 +26,7 @@ import com.cloudhopper.commons.util.windowing.OfferTimeoutException;
 import com.cloudhopper.commons.util.windowing.WindowFuture;
 import com.cloudhopper.smpp.PduAsyncResponse;
 import com.cloudhopper.smpp.SmppBindType;
+import com.cloudhopper.smpp.SmppClientSession;
 import com.cloudhopper.smpp.SmppConstants;
 import com.cloudhopper.smpp.SmppSession;
 import com.cloudhopper.smpp.SmppSessionConfiguration;
@@ -120,9 +121,9 @@ public class DefaultSmppSessionTest {
         // change this to a port we know a server isn't running on
         configuration.setPort(PORT+1);
         
-        DefaultSmppSession session = null;
+        SmppClientSession session = null;
         try {
-            session = (DefaultSmppSession)bootstrap.bind(configuration);
+            session = (SmppClientSession)bootstrap.bind(configuration);
             Assert.fail();
         } catch (SmppChannelConnectException e) {
             // correct behavior
@@ -137,9 +138,9 @@ public class DefaultSmppSessionTest {
         // change to a host that doesn't exist
         configuration.setHost("jfjdjdjdjdjjdjd");
 
-        DefaultSmppSession session = null;
+        SmppClientSession session = null;
         try {
-            session = (DefaultSmppSession)bootstrap.bind(configuration);
+            session = (SmppClientSession)bootstrap.bind(configuration);
             Assert.fail();
         } catch (SmppChannelConnectException e) {
             // correct behavior
@@ -156,9 +157,9 @@ public class DefaultSmppSessionTest {
         configuration.setHost("www.twitter.com");
         configuration.setPort(81);
 
-        DefaultSmppSession session = null;
+        SmppClientSession session = null;
         try {
-            session = (DefaultSmppSession)bootstrap.bind(configuration);
+            session = (SmppClientSession)bootstrap.bind(configuration);
             Assert.fail();
         } catch (SmppChannelConnectTimeoutException e) {
             // correct behavior
@@ -173,9 +174,9 @@ public class DefaultSmppSessionTest {
         SmppSessionConfiguration configuration = createDefaultConfiguration();
         unregisterServerBindProcessor();
 
-        DefaultSmppSession session = null;
+        SmppClientSession session = null;
         try {
-            session = (DefaultSmppSession)bootstrap.bind(configuration);
+            session = (SmppClientSession)bootstrap.bind(configuration);
             Assert.fail();
         } catch (SmppTimeoutException e) {
             // correct behavior (underlying cause MUST be a response timeout)
@@ -194,9 +195,9 @@ public class DefaultSmppSessionTest {
         // set a bad system id
         configuration.setSystemId("BADID");
 
-        DefaultSmppSession session = null;
+        SmppClientSession session = null;
         try {
-            session = (DefaultSmppSession)bootstrap.bind(configuration);
+            session = (SmppClientSession)bootstrap.bind(configuration);
             Assert.fail();
         } catch (SmppBindException e) {
             // correct behavior
@@ -212,7 +213,7 @@ public class DefaultSmppSessionTest {
         SmppSessionConfiguration configuration = createDefaultConfiguration();
         registerServerBindProcessor();
 
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration);
 
         // verify the session stuff...
         Assert.assertEquals(true, session.isBound());
@@ -227,7 +228,7 @@ public class DefaultSmppSessionTest {
         clearAllServerSessions();
 
         // bind and get the simulator session
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration);
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         // register a generic nack will come next
         simulator0.setPduProcessor(new SmppSimulatorPduProcessor() {
@@ -257,7 +258,7 @@ public class DefaultSmppSessionTest {
         clearAllServerSessions();
 
         // bind and get the simulator session
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration);
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         // create an enquire link response back -- we should skip it and wait for a response instead
         simulator0.setPduProcessor(new SmppSimulatorPduProcessor() {
@@ -291,7 +292,7 @@ public class DefaultSmppSessionTest {
         clearAllServerSessions();
 
         // bind and get the simulator session
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration);
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         // create an enquire link response back -- we should skip it and wait for a response instead
         simulator0.setPduProcessor(new SmppSimulatorPduProcessor() {
@@ -323,7 +324,7 @@ public class DefaultSmppSessionTest {
         configuration.setWindowSize(3);
 
         // bind and get the simulator session
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration);
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         // make sure the processor is null
         simulator0.setPduProcessor(null);
@@ -400,7 +401,7 @@ public class DefaultSmppSessionTest {
 
         // bind and get the simulator session
         PollableSmppSessionHandler sessionHandler = new PollableSmppSessionHandler();
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration, sessionHandler);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration, sessionHandler);
 
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         simulator0.setPduProcessor(null);
@@ -443,7 +444,7 @@ public class DefaultSmppSessionTest {
 
         // bind and get the simulator session
         PollableSmppSessionHandler sessionHandler = new PollableSmppSessionHandler();
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration, sessionHandler);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration, sessionHandler);
 
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         simulator0.setPduProcessor(new SmppSimulatorPduProcessor() {
@@ -483,7 +484,7 @@ public class DefaultSmppSessionTest {
 
         // bind and get the simulator session
         PollableSmppSessionHandler sessionHandler = new PollableSmppSessionHandler();
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration, sessionHandler);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration, sessionHandler);
 
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         simulator0.setPduProcessor(null);
@@ -521,7 +522,7 @@ public class DefaultSmppSessionTest {
 
         // bind and get the simulator session
         PollableSmppSessionHandler sessionHandler = new PollableSmppSessionHandler();
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration, sessionHandler);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration, sessionHandler);
 
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         simulator0.setPduProcessor(null);
@@ -579,7 +580,7 @@ public class DefaultSmppSessionTest {
 
         // bind and get the simulator session
         PollableSmppSessionHandler sessionHandler = new PollableSmppSessionHandler();
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration, sessionHandler);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration, sessionHandler);
 
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         simulator0.setPduProcessor(null);
@@ -619,7 +620,7 @@ public class DefaultSmppSessionTest {
 
         // bind and get the simulator session
         PollableSmppSessionHandler sessionHandler = new PollableSmppSessionHandler();
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration, sessionHandler);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration, sessionHandler);
 
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         simulator0.setPduProcessor(null);
@@ -640,7 +641,7 @@ public class DefaultSmppSessionTest {
 
         // bind and get the simulator session
         PollableSmppSessionHandler sessionHandler = new PollableSmppSessionHandler();
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration, sessionHandler);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration, sessionHandler);
 
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         simulator0.setPduProcessor(null);
@@ -660,7 +661,7 @@ public class DefaultSmppSessionTest {
 
         // bind and get the simulator session
         PollableSmppSessionHandler sessionHandler = new PollableSmppSessionHandler();
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration, sessionHandler);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration, sessionHandler);
 
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         simulator0.setPduProcessor(new SmppSimulatorPduProcessor() {
@@ -686,7 +687,7 @@ public class DefaultSmppSessionTest {
 
         // bind and get the simulator session
         PollableSmppSessionHandler sessionHandler = new PollableSmppSessionHandler();
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration, sessionHandler);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration, sessionHandler);
 
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         simulator0.setPduProcessor(null);
@@ -719,7 +720,7 @@ public class DefaultSmppSessionTest {
 
         // bind and get the simulator session
         PollableSmppSessionHandler sessionHandler = new PollableSmppSessionHandler();
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration, sessionHandler);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration, sessionHandler);
 
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         simulator0.setPduProcessor(null);
@@ -750,7 +751,7 @@ public class DefaultSmppSessionTest {
 
         // bind and get the simulator session
         PollableSmppSessionHandler sessionHandler = new PollableSmppSessionHandler();
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration, sessionHandler);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration, sessionHandler);
 
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         simulator0.setPduProcessor(null);
@@ -789,7 +790,7 @@ public class DefaultSmppSessionTest {
 
         // bind and get the simulator session
         PollableSmppSessionHandler sessionHandler = new PollableSmppSessionHandler();
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration, sessionHandler);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration, sessionHandler);
 
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         simulator0.setPduProcessor(null);
@@ -834,7 +835,7 @@ public class DefaultSmppSessionTest {
 
         // bind and get the simulator session
         PollableSmppSessionHandler sessionHandler = new PollableSmppSessionHandler();
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration, sessionHandler);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration, sessionHandler);
 
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         simulator0.setPduProcessor(null);
@@ -892,7 +893,7 @@ public class DefaultSmppSessionTest {
 
         // bind and get the simulator session
         PollableSmppSessionHandler sessionHandler = new PollableSmppSessionHandler();
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration, sessionHandler);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration, sessionHandler);
 
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         simulator0.setPduProcessor(null);
@@ -938,7 +939,7 @@ public class DefaultSmppSessionTest {
 
         // bind and get the simulator session
         PollableSmppSessionHandler sessionHandler = new PollableSmppSessionHandler();
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration, sessionHandler);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration, sessionHandler);
 
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         simulator0.setPduProcessor(null);
@@ -976,7 +977,7 @@ public class DefaultSmppSessionTest {
 
         // bind and get the simulator session
         PollableSmppSessionHandler sessionHandler = new PollableSmppSessionHandler();
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration, sessionHandler);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration, sessionHandler);
 
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         simulator0.setPduProcessor(null);
@@ -1006,7 +1007,7 @@ public class DefaultSmppSessionTest {
 
         // bind and get the simulator session
         PollableSmppSessionHandler sessionHandler = new PollableSmppSessionHandler();
-        DefaultSmppSession session = (DefaultSmppSession)bootstrap.bind(configuration, sessionHandler);
+        SmppClientSession session = (SmppClientSession)bootstrap.bind(configuration, sessionHandler);
 
         SmppSimulatorSessionHandler simulator0 = server.pollNextSession(1000);
         simulator0.setPduProcessor(null);


### PR DESCRIPTION
This is just some refactoring.
Before this refactoring `DefaultSmppSession` had server side methods like `serverReady()` and has also client side methods like `bind(BaseBind, timeout)` and `submit(SubmitSm, timeout)`.

`DefaultSmppSession` became `AbstractSmppSession`, and it is the base for the class:
- `DefaultSmppClientSession` which is in charged of client side sessions and implements the interface `SmppClientSession`
- `DefaultSmppServerSession` which is in charged of server side sessions and implements then interface `SmppServerSession`
